### PR TITLE
Fix blog creator selection clearing on save

### DIFF
--- a/src/components/admin/KIBlogCreator.tsx
+++ b/src/components/admin/KIBlogCreator.tsx
@@ -49,7 +49,12 @@ const KIBlogCreator: React.FC = () => {
     setDebugLogs(prev => [...prev, `Enhanced KI Blog Creator geladen - ${trendTags.length} Trend-Tags aktiv`]);
   }, [category, season]);
 
-  const handleSaveArticle = async (content: string, title: string, quality: any) => {
+  const handleSaveArticle = async (
+    content: string,
+    title: string,
+    quality: any,
+    suggestion?: string
+  ) => {
     try {
       console.log("Speichere Enhanced Artikel:", { title, quality: quality.score });
       toast({
@@ -57,10 +62,21 @@ const KIBlogCreator: React.FC = () => {
         description: `"${title}" wurde mit Quality Score ${quality.score} gespeichert.`,
       });
       
-      // Reset nach dem Speichern
-      setSelectedPrompt("");
-      setSuggestionSelections([]);
-      setDebugLogs(prev => [...prev, `Enhanced Artikel "${title}" erfolgreich gespeichert (Quality: ${quality.score})`]);
+      // Entferne gespeicherten Vorschlag aus der Auswahl
+      if (suggestion) {
+        setSuggestionSelections(prev => prev.filter(s => s !== suggestion));
+
+        if (selectedPrompt === suggestion) {
+          setSelectedPrompt("");
+        }
+      } else {
+        setSelectedPrompt("");
+      }
+
+      setDebugLogs(prev => [
+        ...prev,
+        `Enhanced Artikel "${title}" erfolgreich gespeichert (Quality: ${quality.score})`
+      ]);
     } catch (error: any) {
       console.error("Fehler beim Speichern:", error);
       toast({
@@ -154,7 +170,9 @@ const KIBlogCreator: React.FC = () => {
                       <h4 className="font-medium mb-3 text-lg">{suggestion}</h4>
                       <EnhancedBlogArticleEditor
                         initialPrompt={suggestion}
-                        onSave={handleSaveArticle}
+                        onSave={(content, title, quality) =>
+                          handleSaveArticle(content, title, quality, suggestion)
+                        }
                         category={category}
                         season={season}
                         audiences={audiences}
@@ -180,7 +198,9 @@ const KIBlogCreator: React.FC = () => {
               <CardContent>
                 <EnhancedBlogArticleEditor
                   initialPrompt={selectedPrompt}
-                  onSave={handleSaveArticle}
+                  onSave={(content, title, quality) =>
+                    handleSaveArticle(content, title, quality, selectedPrompt)
+                  }
                   category={category}
                   season={season}
                   audiences={audiences}


### PR DESCRIPTION
## Summary
- keep other enhanced blog articles after saving one
- pass the suggestion prompt to the save handler

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ecc611bc08320927b5a82aa5a8eee