### PR TITLE
Switch to published_at in blog test

### DIFF
--- a/src/services/BlogTestingService.ts
+++ b/src/services/BlogTestingService.ts
@@ -71,7 +71,7 @@ class BlogTestingService {
       // Test SELECT
       const { data: posts, error: selectError } = await supabase
         .from('blog_posts')
-        .select('id, title, slug, published, created_at')
+        .select('id, title, slug, published, published_at')
         .limit(5);
 
       if (selectError) throw selectError;


### PR DESCRIPTION
## Summary
- tweak blog post test to select `published_at`

## Testing
- `npm run lint` *(fails: Use "@ts-expect-error" instead of "@ts-ignore", etc.)*
- `npm test` *(fails: BlogPostPipelineService saveBlogPost database error)*

------
https://chatgpt.com/codex/tasks/task_e_684fbddf4ecc8320823deac5199c7b5c