### PR TITLE
Fix admin TypeScript errors

### DIFF
--- a/src/components/admin/EditBlogPostModal.tsx
+++ b/src/components/admin/EditBlogPostModal.tsx
@@ -102,7 +102,7 @@ const EditBlogPostModal: React.FC<EditBlogPostModalProps> = ({ post, onClose, on
         .from("blog_posts")
         .select("*")
         .eq("id", post.id)
-        .single();
+        .single<any>();
 
       if (fetchError) throw fetchError;
 
@@ -118,7 +118,7 @@ const EditBlogPostModal: React.FC<EditBlogPostModalProps> = ({ post, onClose, on
           category: current.category,
           tags: current.tags,
           content_types: current.content_types,
-          season: current.season || null,
+          season: (current as any).season || null,
           audiences: current.audiences,
           featured_image: current.featured_image,
           og_image: current.og_image,

--- a/src/components/admin/SecurityAuditLog.tsx
+++ b/src/components/admin/SecurityAuditLog.tsx
@@ -36,10 +36,11 @@ const SecurityAuditLog: React.FC = () => {
 
       if (error) throw error;
 
-      // Transform data to handle IP address type
+      // Transform data to handle IP address type and narrow severity
       const transformedEvents: SecurityEvent[] = (data || []).map(event => ({
         ...event,
         ip_address: event.ip_address ? String(event.ip_address) : null,
+        severity: event.severity as SecurityEvent['severity']
       }));
 
       setEvents(transformedEvents);

--- a/src/components/admin/pipeline/usePipelineManager.tsx
+++ b/src/components/admin/pipeline/usePipelineManager.tsx
@@ -1,12 +1,17 @@
 
 import { useState, useEffect } from "react";
-import { ContentPipeline } from "./PipelineCard";
-import { PipelineConfig } from "./PipelineConfiguration";
+import type { AutomationPipeline, PipelineConfig } from "@/services/PipelineService";
+
+interface ContentPipeline extends AutomationPipeline {
+  isActive: boolean;
+  lastRun?: Date;
+}
 
 export const usePipelineManager = () => {
   const [pipelines, setPipelines] = useState<ContentPipeline[]>([]);
   const [pipelineConfig, setPipelineConfig] = useState<PipelineConfig>({
-    batchSize: 5,
+    id: '',
+    batch_size: 5,
     quality_threshold: 80,
     auto_publish: false,
     target_category: 'kochen'

--- a/src/components/admin/views/BlogPostsView.tsx
+++ b/src/components/admin/views/BlogPostsView.tsx
@@ -11,7 +11,7 @@ interface BlogPostsViewProps {
   error: string | null;
   onToggleStatus: (id: string, currentStatus: string) => void;
   onDelete: (id: string) => void;
-  onEdit: (post: AdminBlogPost) => void;
+  onEdit?: (post: AdminBlogPost) => void;
 }
 
 const BlogPostsView: React.FC<BlogPostsViewProps> = ({ posts, loading, error, onToggleStatus, onDelete, onEdit }) => {
@@ -63,7 +63,7 @@ const BlogPostsView: React.FC<BlogPostsViewProps> = ({ posts, loading, error, on
                 <Button
                   size="sm"
                   variant="outline"
-                  onClick={() => onEdit(post)}
+                  onClick={() => onEdit?.(post)}
                 >
                   <Edit className="h-4 w-4" />
                 </Button>

--- a/src/hooks/useAdminActions.ts
+++ b/src/hooks/useAdminActions.ts
@@ -93,7 +93,7 @@ export const useAdminActions = () => {
         .from(table)
         .select('*')
         .eq('id', id)
-        .single();
+        .single<any>();
       if (fetchError) throw fetchError;
 
       if (current) {
@@ -201,7 +201,7 @@ export const useAdminActions = () => {
         .from(table)
         .select('*')
         .eq('id', id)
-        .single();
+        .single<any>();
       if (fetchError) throw fetchError;
 
       if (current) {


### PR DESCRIPTION
## Summary
- make blog post edit handler optional
- narrow severity type in SecurityAuditLog
- fix pipeline manager typings
- loosen types for blog post editing and admin actions

## Testing
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684fc38c992483208e1854cdcb69d80f