### PR TITLE
Fix TS types for pipeline manager

### DIFF
--- a/src/components/admin/pipeline/usePipelineManager.tsx
+++ b/src/components/admin/pipeline/usePipelineManager.tsx
@@ -27,6 +27,8 @@ export const usePipelineManager = () => {
         id: 'blog_auto',
         name: 'Automatische Blog-Erstellung',
         type: 'blog_creation',
+        status: 'inactive',
+        config: {},
         isActive: false,
         throughput: 12,
         efficiency: 87,
@@ -43,6 +45,8 @@ export const usePipelineManager = () => {
         id: 'recipe_auto',
         name: 'Automatische Rezept-Generierung',
         type: 'recipe_generation',
+        status: 'inactive',
+        config: {},
         isActive: false,
         throughput: 8,
         efficiency: 92,
@@ -58,6 +62,8 @@ export const usePipelineManager = () => {
         id: 'seo_optimizer',
         name: 'SEO-Optimierungs-Pipeline',
         type: 'seo_optimization',
+        status: 'inactive',
+        config: {},
         isActive: false,
         throughput: 20,
         efficiency: 94,
@@ -72,6 +78,8 @@ export const usePipelineManager = () => {
         id: 'content_analyzer',
         name: 'Content-Performance-Analyse',
         type: 'content_analysis',
+        status: 'active',
+        config: {},
         isActive: true,
         throughput: 50,
         efficiency: 98,
@@ -92,6 +100,7 @@ export const usePipelineManager = () => {
     if (!pipeline) return;
 
     pipeline.isActive = true;
+    pipeline.status = 'active';
     pipeline.lastRun = new Date();
     
     pipeline.stages.forEach(stage => {
@@ -107,6 +116,7 @@ export const usePipelineManager = () => {
     const pipeline = pipelines.find(p => p.id === pipelineId);
     if (pipeline) {
       pipeline.isActive = false;
+      pipeline.status = 'inactive';
       pipeline.stages.forEach(stage => {
         if (stage.status === 'running') stage.status = 'idle';
       });
@@ -118,6 +128,7 @@ export const usePipelineManager = () => {
     const pipeline = pipelines.find(p => p.id === pipelineId);
     if (pipeline) {
       pipeline.isActive = false;
+      pipeline.status = 'inactive';
       pipeline.stages.forEach(stage => {
         stage.status = 'idle';
         stage.progress = 0;
@@ -130,6 +141,7 @@ export const usePipelineManager = () => {
     const pipeline = pipelines.find(p => p.id === pipelineId);
     if (!pipeline) return;
 
+    pipeline.status = 'active';
     for (let i = 0; i < pipeline.stages.length; i++) {
       const stage = pipeline.stages[i];
       stage.status = 'running';
@@ -143,11 +155,15 @@ export const usePipelineManager = () => {
       stage.status = Math.random() > 0.1 ? 'completed' : 'failed';
       if (stage.status === 'failed') {
         pipeline.isActive = false;
+        pipeline.status = 'error';
         break;
       }
     }
-    
+
     pipeline.isActive = false;
+    if (pipeline.status !== 'error') {
+      pipeline.status = 'inactive';
+    }
     setPipelines([...pipelines]);
   };
 

--- a/src/services/PipelineService.ts
+++ b/src/services/PipelineService.ts
@@ -61,8 +61,11 @@ class PipelineService {
 
     return (data || []).map(pipeline => ({
       ...pipeline,
-      stages: JSON.parse(pipeline.stages || '[]')
-    }));
+      stages: JSON.parse((pipeline.stages as string) || '[]'),
+      config: typeof pipeline.config === 'string'
+        ? JSON.parse(pipeline.config as string)
+        : (pipeline.config || {})
+    })) as AutomationPipeline[];
   }
 
   async getConfig(): Promise<PipelineConfig | null> {
@@ -126,7 +129,7 @@ class PipelineService {
 
     if (pipelineError) throw pipelineError;
 
-    const stages = JSON.parse(pipeline.stages || '[]');
+    const stages = JSON.parse((pipeline.stages as string) || '[]');
     const resetStages = stages.map((stage: PipelineStage) => ({
       ...stage,
       status: 'idle',
@@ -158,7 +161,7 @@ class PipelineService {
     const { data, error } = await query;
     if (error) throw error;
 
-    return data || [];
+    return (data || []) as PipelineExecution[];
   }
 
   async getStats(): Promise<PipelineStats> {


### PR DESCRIPTION
## Summary
- update default pipeline definitions to include `status` and `config`
- cast Supabase JSON fields when loading pipelines and executions
- update pipeline state handlers to set status correctly

## Testing
- `npx tsc -p tsconfig.app.json --noEmit`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_684fce758d148320a1539facd0591841