### PR TITLE
Expose Phase dashboards

### DIFF
--- a/src/components/admin/AdminContent.tsx
+++ b/src/components/admin/AdminContent.tsx
@@ -10,6 +10,8 @@ import SowingCalendarView from "./views/SowingCalendarView";
 import AutomatisierungView from "./views/AutomatisierungView";
 import ContentStrategyView from "./views/ContentStrategyView";
 import SecurityLogView from "./views/SecurityLogView";
+import Phase2Dashboard from "./Phase2Dashboard";
+import Phase3Dashboard from "./Phase3Dashboard";
 
 interface AdminContentProps {
   activeView: AdminView;
@@ -89,6 +91,10 @@ const AdminContent: React.FC<AdminContentProps> = ({
         return <SowingCalendarView />;
       case "security-log":
         return <SecurityLogView />;
+      case "phase2":
+        return <Phase2Dashboard />;
+      case "phase3":
+        return <Phase3Dashboard />;
       default:
         return <div>View nicht gefunden</div>;
     }

--- a/src/config/adminMenu.ts
+++ b/src/config/adminMenu.ts
@@ -1,6 +1,6 @@
 
-import { 
-  FileText, 
+import {
+  FileText,
   Users,
   Calendar,
   Shield,
@@ -8,7 +8,9 @@ import {
   TrendingUp,
   ChefHat,
   PenTool,
-  Zap
+  Zap,
+  Brain,
+  Workflow
 } from "lucide-react";
 import { AdminView } from "@/types/admin";
 
@@ -46,6 +48,13 @@ export const menuItems: MenuGroup[] = [
       { key: "automatisierung", label: "Automatisierung", icon: Zap },
       { key: "sowing-calendar", label: "Aussaat-Kalender", icon: Calendar },
       { key: "security-log", label: "Sicherheits-Log", icon: Shield }
+    ]
+  },
+  {
+    group: "Dashboards",
+    items: [
+      { key: "phase2", label: "Content Hub", icon: Brain },
+      { key: "phase3", label: "Automation Hub", icon: Workflow }
     ]
   }
 ];


### PR DESCRIPTION
## Summary
- add advanced dashboard menu entries (Content Hub & Automation Hub)
- render new phase dashboards in AdminContent

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850021e500c83208db27524181a5274