### PR TITLE
Add admin system test routing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -85,7 +85,7 @@ function App() {
               <Route path="/datenschutz" element={<Datenschutz />} />
               <Route path="/impressum" element={<Impressum />} />
               <Route path="/profil" element={<ProfilePage />} />
-              <Route path="/admin" element={<AdminProtectedRoute><AdminDashboard /></AdminProtectedRoute>} />
+              <Route path="/admin/:view?/:slug?" element={<AdminProtectedRoute><AdminDashboard /></AdminProtectedRoute>} />
               <Route path="/kontakt" element={<ContactPage />} />
               <Route path="/newsletter-confirm" element={<NewsletterConfirmPage />} />
               <Route path="/login" element={<LoginPage />} />

--- a/src/components/admin/AdminContent.tsx
+++ b/src/components/admin/AdminContent.tsx
@@ -10,6 +10,7 @@ import SowingCalendarView from "./views/SowingCalendarView";
 import AutomatisierungView from "./views/AutomatisierungView";
 import ContentStrategyView from "./views/ContentStrategyView";
 import SecurityLogView from "./views/SecurityLogView";
+import BlogTestingView from "./views/BlogTestingView";
 
 interface AdminContentProps {
   activeView: AdminView;
@@ -25,6 +26,7 @@ interface AdminContentProps {
   onEditRecipe: (recipe: AdminRecipe) => void;
   onEditBlogPost: (post: AdminBlogPost) => void;
   onDataRefresh: () => void;
+  testSlug?: string;
 }
 
 const AdminContent: React.FC<AdminContentProps> = ({
@@ -41,6 +43,7 @@ const AdminContent: React.FC<AdminContentProps> = ({
   onEditRecipe,
   onEditBlogPost,
   onDataRefresh,
+  testSlug,
 }) => {
   const renderContent = () => {
     switch (activeView) {
@@ -89,6 +92,8 @@ const AdminContent: React.FC<AdminContentProps> = ({
         return <SowingCalendarView />;
       case "security-log":
         return <SecurityLogView />;
+      case "blog-testing":
+        return <BlogTestingView testSlug={testSlug} />;
       default:
         return <div>View nicht gefunden</div>;
     }

--- a/src/components/admin/BlogSystemTestDashboard.tsx
+++ b/src/components/admin/BlogSystemTestDashboard.tsx
@@ -8,7 +8,11 @@ import { Play, CheckCircle, XCircle, Clock, Database, Zap, FileText, Settings } 
 import { blogTestingService, BlogTestResult } from "@/services/BlogTestingService";
 import { useToast } from "@/hooks/use-toast";
 
-const BlogSystemTestDashboard: React.FC = () => {
+interface BlogSystemTestDashboardProps {
+  testSlug?: string;
+}
+
+const BlogSystemTestDashboard: React.FC<BlogSystemTestDashboardProps> = ({ testSlug }) => {
   const [isRunning, setIsRunning] = useState(false);
   const [testResults, setTestResults] = useState<BlogTestResult[]>([]);
   const [testSummary, setTestSummary] = useState<{ total: number; passed: number; failed: number } | null>(null);
@@ -18,11 +22,13 @@ const BlogSystemTestDashboard: React.FC = () => {
     setIsRunning(true);
     setTestResults([]);
     setTestSummary(null);
-    
+
     try {
       console.log("[TestDashboard] Starte Blog-System-Tests...");
-      
-      const results = await blogTestingService.runFullBlogSystemTest();
+
+      const results = testSlug
+        ? [await blogTestingService.runTestBySlug(testSlug)]
+        : await blogTestingService.runFullBlogSystemTest();
       setTestResults(results);
       
       const summary = blogTestingService.getTestSummary();

--- a/src/components/admin/views/BlogTestingView.tsx
+++ b/src/components/admin/views/BlogTestingView.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { TestTube, ArrowLeft } from "lucide-react";
+import BlogSystemTestDashboard from "../BlogSystemTestDashboard";
+import { blogTestingService } from "@/services/BlogTestingService";
+
+interface BlogTestingViewProps {
+  testSlug?: string;
+}
+
+const BlogTestingView: React.FC<BlogTestingViewProps> = ({ testSlug }) => {
+  if (testSlug) {
+    const info = blogTestingService
+      .getAvailableTests()
+      .find((t) => t.slug === testSlug);
+    if (!info) {
+      return <div className="p-4">Unbekannter Test.</div>;
+    }
+    return (
+      <div className="space-y-4">
+        <Link to=".." className="flex items-center text-sm text-sage-600">
+          <ArrowLeft className="h-4 w-4 mr-1" /> Zurück
+        </Link>
+        <BlogSystemTestDashboard testSlug={testSlug} />
+      </div>
+    );
+  }
+
+  const tests = blogTestingService.getAvailableTests();
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-3">
+        <div className="p-2 bg-purple-100 rounded-lg">
+          <TestTube className="h-6 w-6 text-purple-600" />
+        </div>
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Blog-System-Tests</h1>
+          <p className="text-gray-600">Wähle einen Test aus oder starte alle</p>
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Tests</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          {tests.map((t) => (
+            <Link
+              key={t.slug}
+              to={t.slug}
+              className="block px-4 py-2 rounded border hover:bg-sage-50"
+            >
+              {t.name}
+            </Link>
+          ))}
+        </CardContent>
+      </Card>
+
+      <BlogSystemTestDashboard />
+    </div>
+  );
+};
+
+export default BlogTestingView;

--- a/src/config/adminMenu.ts
+++ b/src/config/adminMenu.ts
@@ -8,7 +8,8 @@ import {
   TrendingUp,
   ChefHat,
   PenTool,
-  Zap
+  Zap,
+  TestTube
 } from "lucide-react";
 import { AdminView } from "@/types/admin";
 
@@ -45,7 +46,8 @@ export const menuItems: MenuGroup[] = [
       { key: "content-strategy", label: "Content-Strategie", icon: TrendingUp },
       { key: "automatisierung", label: "Automatisierung", icon: Zap },
       { key: "sowing-calendar", label: "Aussaat-Kalender", icon: Calendar },
-      { key: "security-log", label: "Sicherheits-Log", icon: Shield }
+      { key: "security-log", label: "Sicherheits-Log", icon: Shield },
+      { key: "blog-testing", label: "System-Tests", icon: TestTube }
     ]
   }
 ];

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -9,9 +9,15 @@ import AdminSidebar from "@/components/admin/AdminSidebar";
 import AdminContent from "@/components/admin/AdminContent";
 import EditRecipeModal from "@/components/admin/EditRecipeModal";
 import EditBlogPostModal from "@/components/admin/EditBlogPostModal";
+import { useParams, useNavigate } from "react-router-dom";
 
 const AdminDashboard: React.FC = () => {
-  const [activeView, setActiveView] = useState<AdminView>("recipes");
+  const params = useParams<{ view?: string; slug?: string }>();
+  const navigate = useNavigate();
+  const [activeView, setActiveView] = useState<AdminView>(
+    (params.view as AdminView) || "recipes"
+  );
+  const testSlug = params.slug;
   const [userEmail, setUserEmail] = useState<string>("");
   const [editingRecipe, setEditingRecipe] = useState<AdminRecipe | null>(null);
   const [editingPost, setEditingPost] = useState<AdminBlogPost | null>(null);
@@ -39,6 +45,12 @@ const AdminDashboard: React.FC = () => {
     };
     getUserEmail();
   }, []);
+
+  useEffect(() => {
+    if (params.view && params.view !== activeView) {
+      setActiveView(params.view as AdminView);
+    }
+  }, [params.view]);
 
   const onToggleStatus = (id: string, status: string, type: 'recipe' | 'blog') => {
     handleToggleStatus(id, status, type, recipes, blogPosts, setRecipes, setBlogPosts);
@@ -83,7 +95,10 @@ const AdminDashboard: React.FC = () => {
         <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
           {/* Sidebar Navigation */}
           <div className="lg:col-span-1">
-            <AdminSidebar activeView={activeView} onViewChange={setActiveView} />
+            <AdminSidebar activeView={activeView} onViewChange={(v) => {
+              setActiveView(v);
+              navigate(`/admin/${v}`);
+            }} />
           </div>
 
           {/* Main Content */}
@@ -102,6 +117,7 @@ const AdminDashboard: React.FC = () => {
             onEditRecipe={onEditRecipe}
             onEditBlogPost={onEditBlogPost}
             onDataRefresh={loadData}
+            testSlug={testSlug}
           />
           {editingRecipe && (
             <EditRecipeModal

--- a/src/services/BlogTestingService.ts
+++ b/src/services/BlogTestingService.ts
@@ -258,13 +258,53 @@ class BlogTestingService {
   getTestSummary(): { total: number; passed: number; failed: number; details: BlogTestResult[] } {
     const passed = this.testResults.filter(r => r.success).length;
     const failed = this.testResults.filter(r => !r.success).length;
-    
+
     return {
       total: this.testResults.length,
       passed,
       failed,
       details: this.testResults
     };
+  }
+
+  /**
+   * Liste verfügbarer Tests mit Slugs
+   */
+  getAvailableTests() {
+    return [
+      { slug: 'supabase-connection', name: 'Supabase Connection' },
+      { slug: 'blog-posts-table', name: 'Blog Posts Table' },
+      { slug: 'content-generation', name: 'Content Generation' },
+      { slug: 'blog-post-creation', name: 'Blog Post Creation' },
+      { slug: 'edge-functions', name: 'Edge Functions' },
+    ];
+  }
+
+  /**
+   * Führt einen einzelnen Test anhand seines Slugs aus
+   */
+  async runTestBySlug(slug: string): Promise<BlogTestResult> {
+    this.testResults = [];
+    switch (slug) {
+      case 'supabase-connection':
+        await this.testSupabaseConnection();
+        break;
+      case 'blog-posts-table':
+        await this.testBlogPostsTable();
+        break;
+      case 'content-generation':
+        await this.testContentGeneration();
+        break;
+      case 'blog-post-creation':
+        await this.testBlogPostCreation();
+        break;
+      case 'edge-functions':
+        await this.testEdgeFunctions();
+        break;
+      default:
+        throw new Error('Unbekannter Test-Slug');
+    }
+    return this.testResults[0];
   }
 }
 


### PR DESCRIPTION
## Summary
- add view for blog system tests
- expose runTestBySlug and available tests in BlogTestingService
- support system test view in admin menu and routing
- handle view switching with url params

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' etc.)*
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68501f052e388320a130a83842bda772