### PR TITLE
Add trend analytics service and keyword gap dashboard

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,6 +6,7 @@ Diese Roadmap beschreibt geplante Erweiterungen und Meilensteine des Projekts.
 - Grundlegende Seitenstruktur aufbauen
 - Nutzer-Authentifizierung über Supabase integrieren
 - CI-Workflow für Linting und Tests einrichten
+- Trenddaten über OpenAI (Edge Function `fetch-current-trends`) abrufen
 
 ## Mittelfristig
 - Admin-Bereich für Inhalte

--- a/src/services/BlogAnalyticsService.ts
+++ b/src/services/BlogAnalyticsService.ts
@@ -1,0 +1,53 @@
+import { supabase } from "@/integrations/supabase/client";
+
+export interface BlogPostInfo {
+  title: string;
+  tags: string[];
+  seo_keywords: string[];
+  category: string;
+  content: string;
+}
+
+export interface TrendKeyword {
+  keyword: string;
+  relevance: number;
+  category: string;
+}
+
+class BlogAnalyticsService {
+  async fetchBlogPosts(): Promise<BlogPostInfo[]> {
+    const { data, error } = await supabase
+      .from('blog_posts')
+      .select('title,tags,seo_keywords,category,content');
+    if (error) throw error;
+    return (data as BlogPostInfo[]) || [];
+  }
+
+  extractKeywords(posts: BlogPostInfo[]): string[] {
+    const freq: Record<string, number> = {};
+    for (const post of posts) {
+      const keywords = [...(post.tags || []), ...(post.seo_keywords || [])];
+      for (const kw of keywords) {
+        const key = kw.toLowerCase();
+        freq[key] = (freq[key] || 0) + 1;
+      }
+    }
+    return Object.entries(freq)
+      .sort((a, b) => b[1] - a[1])
+      .map(([k]) => k);
+  }
+
+  async fetchCurrentTrends(): Promise<TrendKeyword[]> {
+    const { data, error } = await supabase.functions.invoke('fetch-current-trends');
+    if (error) throw error;
+    return (data?.trends || data) as TrendKeyword[];
+  }
+
+  findKeywordGaps(trends: TrendKeyword[], existing: string[]): TrendKeyword[] {
+    const lowerExisting = existing.map(k => k.toLowerCase());
+    return trends.filter(t => !lowerExisting.includes(t.keyword.toLowerCase()));
+  }
+}
+
+export const blogAnalyticsService = new BlogAnalyticsService();
+export type { BlogAnalyticsService };

--- a/supabase/functions/fetch-current-trends/index.ts
+++ b/supabase/functions/fetch-current-trends/index.ts
@@ -1,0 +1,64 @@
+import "https://deno.land/x/xhr@0.1.0/mod.ts";
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { corsHeaders } from "../_shared/cors.ts";
+
+const openAIApiKey = Deno.env.get("OPENAI_API_KEY");
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    if (!openAIApiKey) {
+      return new Response(
+        JSON.stringify({ error: "OPENAI_API_KEY not set" }),
+        { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      );
+    }
+
+    const prompt = `Du bist ein deutschsprachiger Trend-Analyst.\nGib mir 5-10 aktuelle Keywords aus den Bereichen Garten und Küche als JSON-Array im Format [{\"keyword\":\"...\",\"relevance\":0.9,\"category\":\"garten\"}].`;
+
+    const response = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${openAIApiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "gpt-4o",
+        messages: [
+          { role: "system", content: "Du lieferst nur JSON ohne Erklärungen." },
+          { role: "user", content: prompt }
+        ],
+        temperature: 0.7,
+        max_tokens: 300,
+      }),
+    });
+
+    if (!response.ok) {
+      const err = await response.text();
+      return new Response(JSON.stringify({ error: err }), {
+        status: response.status,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const data = await response.json();
+    const content = data.choices?.[0]?.message?.content || "[]";
+    let trends;
+    try {
+      trends = JSON.parse(content);
+    } catch (_) {
+      trends = [];
+    }
+    return new Response(JSON.stringify(trends), {
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  } catch (err) {
+    return new Response(JSON.stringify({ error: String(err) }), {
+      status: 500,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- analyze blog keywords via new `BlogAnalyticsService`
- fetch current trends with new edge function
- highlight missing trend keywords in content strategy
- show keyword gaps in the dashboard
- note the new edge function in the roadmap

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(prompted to install vitest)*

------
https://chatgpt.com/codex/tasks/task_e_685121b9ac688320a701e78e0d70b48e