### PR TITLE
centralize color palette

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -12,10 +12,10 @@
   transition: filter 300ms;
 }
 .logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
+  filter: drop-shadow(0 0 2em var(--vite-logo-shadow));
 }
 .logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+  filter: drop-shadow(0 0 2em var(--react-logo-shadow));
 }
 
 @keyframes logo-spin {
@@ -38,5 +38,5 @@
 }
 
 .read-the-docs {
-  color: #888;
+  color: var(--card-text);
 }

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -2,6 +2,7 @@ import * as React from "react"
 import * as RechartsPrimitive from "recharts"
 
 import { cn } from "@/lib/utils"
+import colors from "@/theme/colors"
 
 // Format: { THEME_NAME: CSS_SELECTOR }
 const THEMES = { light: "", dark: ".dark" } as const
@@ -50,7 +51,7 @@ const ChartContainer = React.forwardRef<
         data-chart={chartId}
         ref={ref}
         className={cn(
-          "flex aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-none [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-sector]:outline-none [&_.recharts-surface]:outline-none",
+          `flex aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='${colors.misc.gridLine}']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='${colors.misc.white}']]:stroke-transparent [&_.recharts-layer]:outline-none [&_.recharts-polar-grid_[stroke='${colors.misc.gridLine}']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='${colors.misc.gridLine}']]:stroke-border [&_.recharts-sector[stroke='${colors.misc.white}']]:stroke-transparent [&_.recharts-sector]:outline-none [&_.recharts-surface]:outline-none`,
           className
         )}
         {...props}

--- a/src/config/site.config.ts
+++ b/src/config/site.config.ts
@@ -52,6 +52,8 @@ export interface SiteConfig {
   };
 }
 
+import colors from "@/theme/colors";
+
 export const siteConfig: SiteConfig = {
   name: "mien-tuun",
   title: "Mien Tuun - Garten, Küche & nachhaltiges Leben",
@@ -76,12 +78,12 @@ export const siteConfig: SiteConfig = {
   favicon: "/favicon.ico",
   
   theme: {
-    primaryColor: "#8B7355", // warmes braun
-    secondaryColor: "#A8B5A0", // salbeigrün  
-    accentColor: "#D4AF8C", // sanftes gold
-    backgroundColor: "#FEFCF8", // cremeweiß
-    textColor: "#2D3319", // dunkelgrün
-    mutedColor: "#8B9A8B", // gedämpftes grün
+    primaryColor: colors.earth[700], // warmes braun
+    secondaryColor: colors.sage[400], // salbeigrün
+    accentColor: colors.accent[400], // sanftes gold
+    backgroundColor: colors.cream, // cremeweiß
+    textColor: colors.sage[900], // dunkelgrün
+    mutedColor: colors.sage[500], // gedämpftes grün
   },
   
   social: {

--- a/src/index.css
+++ b/src/index.css
@@ -2,7 +2,9 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Definition of the design system. All colors, gradients, fonts, etc should be defined here. */
+/* Definition of the design system. All colors, gradients, fonts, etc should be
+   defined here. The values mirror src/theme/colors.ts so that the palette is
+   centrally managed. */
 
 @layer base {
   :root {
@@ -51,6 +53,10 @@
     --sidebar-border: 220 13% 91%;
 
     --sidebar-ring: 217.2 91.2% 59.8%;
+    --vite-logo-shadow: #646cffaa;
+    --react-logo-shadow: #61dafbaa;
+    --card-text: #888;
+    --email-link: #19793a;
   }
 
   .dark {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,8 @@
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
+import { applyColors } from './theme/colors'
+
+applyColors()
 
 createRoot(document.getElementById("root")!).render(<App />);

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -1,0 +1,128 @@
+export const earth = {
+  50: '#FEFCF8',
+  100: '#FDF9F1',
+  200: '#F9F1E6',
+  300: '#F2E6D0',
+  400: '#E6D1B0',
+  500: '#D4AF8C',
+  600: '#B8956F',
+  700: '#8B7355',
+  800: '#6B5642',
+  900: '#4A3C2F',
+} as const;
+
+export const sage = {
+  50: '#F6F8F6',
+  100: '#EDF2ED',
+  200: '#D8E3D8',
+  300: '#B8C9B8',
+  400: '#A8B5A0',
+  500: '#8B9A8B',
+  600: '#6F7F6F',
+  700: '#556655',
+  800: '#3D4F3D',
+  900: '#2D3319',
+} as const;
+
+export const accent = {
+  50: '#FDF9F3',
+  100: '#FAF0E4',
+  200: '#F4E0C6',
+  300: '#EBCB9F',
+  400: '#D4AF8C',
+  500: '#C19660',
+  600: '#A67B4A',
+  700: '#8B6439',
+  800: '#6F4F2B',
+  900: '#573E20',
+} as const;
+
+export const cream = '#FEFCF8';
+
+export const misc = {
+  emailLink: '#19793a',
+  viteLogoShadow: '#646cffaa',
+  reactLogoShadow: '#61dafbaa',
+  cardText: '#888',
+  gridLine: '#ccc',
+  white: '#fff',
+} as const;
+
+export const themeLight = {
+  background: '0 0% 100%',
+  foreground: '222.2 84% 4.9%',
+  card: '0 0% 100%',
+  cardForeground: '222.2 84% 4.9%',
+  popover: '0 0% 100%',
+  popoverForeground: '222.2 84% 4.9%',
+  primary: '222.2 47.4% 11.2%',
+  primaryForeground: '210 40% 98%',
+  secondary: '210 40% 96.1%',
+  secondaryForeground: '222.2 47.4% 11.2%',
+  muted: '210 40% 96.1%',
+  mutedForeground: '215.4 16.3% 46.9%',
+  accent: '210 40% 96.1%',
+  accentForeground: '222.2 47.4% 11.2%',
+  destructive: '0 84.2% 60.2%',
+  destructiveForeground: '210 40% 98%',
+  border: '214.3 31.8% 91.4%',
+  input: '214.3 31.8% 91.4%',
+  ring: '222.2 84% 4.9%',
+  radius: '0.5rem',
+  sidebarBackground: '0 0% 98%',
+  sidebarForeground: '240 5.3% 26.1%',
+  sidebarPrimary: '240 5.9% 10%',
+  sidebarPrimaryForeground: '0 0% 98%',
+  sidebarAccent: '240 4.8% 95.9%',
+  sidebarAccentForeground: '240 5.9% 10%',
+  sidebarBorder: '220 13% 91%',
+  sidebarRing: '217.2 91.2% 59.8%',
+} as const;
+
+export const themeDark = {
+  background: '222.2 84% 4.9%',
+  foreground: '210 40% 98%',
+  card: '222.2 84% 4.9%',
+  cardForeground: '210 40% 98%',
+  popover: '222.2 84% 4.9%',
+  popoverForeground: '210 40% 98%',
+  primary: '210 40% 98%',
+  primaryForeground: '222.2 47.4% 11.2%',
+  secondary: '217.2 32.6% 17.5%',
+  secondaryForeground: '210 40% 98%',
+  muted: '217.2 32.6% 17.5%',
+  mutedForeground: '215 20.2% 65.1%',
+  accent: '217.2 32.6% 17.5%',
+  accentForeground: '210 40% 98%',
+  destructive: '0 62.8% 30.6%',
+  destructiveForeground: '210 40% 98%',
+  border: '217.2 32.6% 17.5%',
+  input: '217.2 32.6% 17.5%',
+  ring: '212.7 26.8% 83.9%',
+  sidebarBackground: '240 5.9% 10%',
+  sidebarForeground: '240 4.8% 95.9%',
+  sidebarPrimary: '224.3 76.3% 48%',
+  sidebarPrimaryForeground: '0 0% 100%',
+  sidebarAccent: '240 3.7% 15.9%',
+  sidebarAccentForeground: '240 4.8% 95.9%',
+  sidebarBorder: '240 3.7% 15.9%',
+  sidebarRing: '217.2 91.2% 59.8%',
+} as const;
+
+export default {
+  earth,
+  sage,
+  accent,
+  cream,
+  misc,
+  themeLight,
+  themeDark,
+};
+
+export function applyColors(mode: 'light' | 'dark' = 'light') {
+  const vars = mode === 'light' ? themeLight : themeDark;
+  const root = document.documentElement;
+  const toVar = (s: string) => `--${s.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase()}`;
+  Object.entries(vars).forEach(([key, value]) => root.style.setProperty(toVar(key), value));
+  Object.entries(misc).forEach(([key, value]) => root.style.setProperty(toVar(key), value));
+}

--- a/supabase/functions/send-newsletter-confirmation/index.ts
+++ b/supabase/functions/send-newsletter-confirmation/index.ts
@@ -2,6 +2,7 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { Resend } from "npm:resend@2.0.0";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.42.6";
+import colors from "../../../src/theme/colors.ts";
 
 // Supabase Setup
 const supabase = createClient(
@@ -74,7 +75,7 @@ const handler = async (req: Request): Promise<Response> => {
       html: `
         <h2>Newsletter-Anmeldung bei ${SITE_NAME}</h2>
         <p>Bitte bestätige deine Anmeldung, indem du auf den folgenden Link klickst:</p>
-        <p><a href="${confirmUrl}" style="color:#19793a;font-weight:bold">Hier Anmeldung bestätigen</a></p>
+        <p><a href="${confirmUrl}" style="color:${colors.misc.emailLink};font-weight:bold">Hier Anmeldung bestätigen</a></p>
         <p>Falls du dich nicht angemeldet hast, ignoriere diese Nachricht einfach.</p>
       `,
     });

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,6 @@
 
 import type { Config } from "tailwindcss";
+import colors from "./src/theme/colors";
 
 export default {
 	darkMode: ["class"],
@@ -19,45 +20,12 @@ export default {
 			}
 		},
 		extend: {
-			colors: {
-				// Custom Theme Colors basierend auf site.config
-				earth: {
-					50: '#FEFCF8',
-					100: '#FDF9F1',
-					200: '#F9F1E6',
-					300: '#F2E6D0',
-					400: '#E6D1B0',
-					500: '#D4AF8C',
-					600: '#B8956F',
-					700: '#8B7355',
-					800: '#6B5642',
-					900: '#4A3C2F',
-				},
-				sage: {
-					50: '#F6F8F6',
-					100: '#EDF2ED',
-					200: '#D8E3D8',
-					300: '#B8C9B8',
-					400: '#A8B5A0',
-					500: '#8B9A8B',
-					600: '#6F7F6F',
-					700: '#556655',
-					800: '#3D4F3D',
-					900: '#2D3319',
-				},
-				accent: {
-					50: '#FDF9F3',
-					100: '#FAF0E4',
-					200: '#F4E0C6',
-					300: '#EBCB9F',
-					400: '#D4AF8C',
-					500: '#C19660',
-					600: '#A67B4A',
-					700: '#8B6439',
-					800: '#6F4F2B',
-					900: '#573E20',
-				},
-				cream: '#FEFCF8',
+                        colors: {
+                                // Custom Theme Colors basierend auf site.config
+                                earth: colors.earth,
+                                sage: colors.sage,
+                                accent: colors.accent,
+                                cream: colors.cream,
 				// Original shadcn colors
 				border: 'hsl(var(--border))',
 				input: 'hsl(var(--input))',


### PR DESCRIPTION
## Summary
- create `src/theme/colors.ts` with all color values
- use the palette in `tailwind.config.ts` and `site.config.ts`
- inject colors at runtime and reference in supabase function
- clean up demo CSS to use variables

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685165deae84832084f5203fb09ad965