### PR TITLE
Fix Smart Creator pipeline

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -168,6 +168,7 @@ export type Database = {
           category: string
           content: string
           content_types: string[]
+          season: string | null
           description: string | null
           excerpt: string
           featured: boolean
@@ -194,6 +195,7 @@ export type Database = {
           category: string
           content: string
           content_types?: string[]
+          season?: string | null
           description?: string | null
           excerpt: string
           featured?: boolean
@@ -220,6 +222,7 @@ export type Database = {
           category?: string
           content?: string
           content_types?: string[]
+          season?: string | null
           description?: string | null
           excerpt?: string
           featured?: boolean

--- a/supabase/migrations/20250616091501-add-season-to-blog-posts.sql
+++ b/supabase/migrations/20250616091501-add-season-to-blog-posts.sql
@@ -1,0 +1,7 @@
+-- Add season column to blog_posts
+ALTER TABLE public.blog_posts
+  ADD COLUMN season TEXT NOT NULL DEFAULT 'ganzjährig'
+    CHECK (season IN ('frühling', 'sommer', 'herbst', 'winter', 'ganzjährig'));
+
+-- Backfill existing rows with default
+UPDATE public.blog_posts SET season = 'ganzjährig' WHERE season IS NULL;


### PR DESCRIPTION
## Summary
- add missing season column migration for blog_posts
- update Supabase types to include the new season field in blog_posts

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' and other errors)*
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6852619d40088320a394faf92cc18471