### PR TITLE
Enhance content strategy insights

### DIFF
--- a/src/services/ContentInsightsService.ts
+++ b/src/services/ContentInsightsService.ts
@@ -1,0 +1,103 @@
+import { supabase } from "@/integrations/supabase/client";
+import type { TrendKeyword } from "./BlogAnalyticsService";
+
+export interface CategoryStat {
+  category: string;
+  count: number;
+}
+
+export interface ScheduledPost {
+  date: string;
+  title: string;
+  slug: string;
+  status: string | null;
+}
+
+export interface ContentSuggestion {
+  topic: string;
+  category: string;
+  reason: string;
+}
+
+interface ContentInsights {
+  categoryStats: CategoryStat[];
+  suggestions: ContentSuggestion[];
+  scheduled: ScheduledPost[];
+}
+
+class ContentInsightsService {
+  async fetchInsights(): Promise<ContentInsights> {
+    const [blogRes, recipeRes, versionRes, trendsRes] = await Promise.all([
+      supabase.from('blog_posts').select('category,tags,seo_keywords'),
+      supabase.from('recipes').select('category,tags'),
+      supabase.from('blog_post_versions').select('title,slug,created_at,status'),
+      supabase.functions.invoke('fetch-current-trends')
+    ]);
+
+    if (blogRes.error) throw blogRes.error;
+    if (recipeRes.error) throw recipeRes.error;
+    if (versionRes.error) throw versionRes.error;
+    if (trendsRes.error) throw trendsRes.error;
+
+    const blogPosts = blogRes.data as { category: string; tags: string[]; seo_keywords: string[] }[];
+    const recipes = recipeRes.data as { category: string; tags: string[] }[];
+    const versions = versionRes.data as { title: string; slug: string; created_at: string; status: string | null }[];
+    const trends = (trendsRes.data?.trends || trendsRes.data) as TrendKeyword[];
+
+    const categoryStats = this.computeCategoryStats(blogPosts, recipes);
+    const suggestions = this.generateSuggestions(trends, blogPosts, recipes, categoryStats);
+    const scheduled = versions.map(v => ({
+      date: v.created_at,
+      title: v.title,
+      slug: v.slug,
+      status: v.status
+    }));
+
+    return { categoryStats, suggestions, scheduled };
+  }
+
+  private computeCategoryStats(
+    blogPosts: { category: string }[],
+    recipes: { category: string }[]
+  ): CategoryStat[] {
+    const counts: Record<string, number> = {};
+    for (const p of blogPosts) {
+      if (p.category) counts[p.category] = (counts[p.category] || 0) + 1;
+    }
+    for (const r of recipes) {
+      if (r.category) counts[r.category] = (counts[r.category] || 0) + 1;
+    }
+    return Object.entries(counts).map(([category, count]) => ({ category, count }));
+  }
+
+  private generateSuggestions(
+    trends: TrendKeyword[],
+    blogPosts: { tags: string[]; seo_keywords?: string[] }[],
+    recipes: { tags: string[] }[],
+    stats: CategoryStat[]
+  ): ContentSuggestion[] {
+    const existing = new Set<string>();
+    for (const p of blogPosts) {
+      [...(p.tags || []), ...(p.seo_keywords || [])].forEach(t => existing.add(t.toLowerCase()));
+    }
+    for (const r of recipes) {
+      (r.tags || []).forEach(t => existing.add(t.toLowerCase()));
+    }
+    const lowCategories = stats.filter(s => s.count < 3).map(s => s.category);
+    const suggestions: ContentSuggestion[] = [];
+    for (const trend of trends) {
+      if (!existing.has(trend.keyword.toLowerCase()) && lowCategories.includes(trend.category)) {
+        suggestions.push({
+          topic: trend.keyword,
+          category: trend.category,
+          reason: `Trendthema '${trend.keyword}' fehlt in Kategorie ${trend.category}`
+        });
+      }
+    }
+    return suggestions;
+  }
+}
+
+export const contentInsightsService = new ContentInsightsService();
+export type { ContentInsightsService };
+export type { ContentInsights };

--- a/src/services/__tests__/ContentInsightsService.test.ts
+++ b/src/services/__tests__/ContentInsightsService.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { contentInsightsService } from '../ContentInsightsService';
+
+const trends = [
+  { keyword: 'Permakultur', relevance: 0.9, category: 'garten' },
+  { keyword: 'Zero Waste', relevance: 0.8, category: 'nachhaltigkeit' }
+];
+
+const blogPosts = [
+  { category: 'garten', tags: ['pflanzen'], seo_keywords: ['garten'] }
+];
+const recipes = [
+  { category: 'kochen', tags: ['suppe'] }
+];
+
+describe('ContentInsightsService', () => {
+  it('detects suggestions for missing categories', () => {
+    const stats = (contentInsightsService as any).computeCategoryStats(blogPosts, recipes);
+    const suggestions = (contentInsightsService as any).generateSuggestions(trends, blogPosts, recipes, stats);
+    expect(suggestions.length).toBe(1);
+    expect(suggestions[0].topic).toBe('Permakultur');
+  });
+});


### PR DESCRIPTION
## Summary
- add `ContentInsightsService` to aggregate blog and recipe data for trends and gaps
- integrate the new service into the Content Strategy dashboard
- display new article suggestions and scheduled posts
- provide simple vitest coverage for insights logic

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852611cc6c4832090fd257e1787341c