### PR TITLE
Improve role checks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import LoginPage from "./pages/LoginPage";
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { supabase } from "@/integrations/supabase/client";
+import { hasRole } from "@/utils/roles";
 
 const queryClient = new QueryClient();
 
@@ -40,14 +41,9 @@ const AdminProtectedRoute: React.FC<{ children: React.ReactNode }> = ({ children
         return;
       }
       const userId = sessionData.session.user.id;
-      const { data } = await supabase
-        .from("user_roles")
-        .select("role")
-        .eq("user_id", userId)
-        .eq("role", "admin")
-        .single();
-      if (isMounted) setIsAllowed(!!data);
-      if (!data) navigate("/profil");
+      const isAdmin = await hasRole(userId, "admin");
+      if (isMounted) setIsAllowed(isAdmin);
+      if (!isAdmin) navigate("/profil");
     };
     check();
     return () => { isMounted = false };

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { siteConfig } from '@/config/site.config';
 import { Menu, X, Flower, Search, LogOut, Shield } from 'lucide-react';
 import { supabase } from "@/integrations/supabase/client";
+import { hasRole } from "@/utils/roles";
 import AuthDialog from "@/components/AuthDialog";
 
 const Header: React.FC = () => {
@@ -24,13 +25,8 @@ const Header: React.FC = () => {
   useEffect(() => {
     const checkAdmin = async () => {
       if (session?.user) {
-        const { data } = await supabase
-          .from("user_roles")
-          .select("role")
-          .eq("user_id", session.user.id)
-          .eq("role", "admin")
-          .single();
-        setIsAdmin(!!data);
+        const isAdmin = await hasRole(session.user.id, "admin");
+        setIsAdmin(isAdmin);
       } else {
         setIsAdmin(false);
       }

--- a/src/components/ProfileForm.tsx
+++ b/src/components/ProfileForm.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { supabase } from "@/integrations/supabase/client";
+import { hasRole } from "@/utils/roles";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
@@ -19,16 +20,6 @@ interface ProfileFormProps {
   onUpdate: (profile: any) => void;
 }
 
-// Hilfsfunktion: Prüfe Admin-Status (für Badge)
-async function isAdmin(userId: string): Promise<boolean> {
-  const { data } = await supabase
-    .from("user_roles")
-    .select("role")
-    .eq("user_id", userId)
-    .eq("role", "admin")
-    .single();
-  return !!data;
-}
 
 const ProfileForm: React.FC<ProfileFormProps> = ({ profile, onUpdate }) => {
   const [form, setForm] = useState({
@@ -44,7 +35,7 @@ const ProfileForm: React.FC<ProfileFormProps> = ({ profile, onUpdate }) => {
   const [avatarValid, setAvatarValid] = useState(true);
 
   useEffect(() => {
-    isAdmin(profile.id).then(setAdmin);
+    hasRole(profile.id, "admin").then(setAdmin);
   }, [profile.id]);
 
   // Sofortige Vorschau/Bildprüfung für Avatar-URL

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -9,6 +9,7 @@ import { useAdminActions } from "@/hooks/useAdminActions";
 import EditBlogPostModal from "@/components/admin/EditBlogPostModal";
 import { AdminBlogPost, AdminView } from "@/types/admin";
 import { supabase } from "@/integrations/supabase/client";
+import { hasRole } from "@/utils/roles";
 
 const AdminDashboard: React.FC = () => {
   const [activeView, setActiveView] = useState<AdminView>("blog-posts");
@@ -36,19 +37,12 @@ const AdminDashboard: React.FC = () => {
   } = useAdminActions();
 
   // Check if user is admin
-  const { data: userRoles, isLoading } = useQuery({
-    queryKey: ["user-roles"],
+  const { data: isAdmin, isLoading } = useQuery({
+    queryKey: ["user-is-admin"],
     queryFn: async () => {
       const { data: { user } } = await supabase.auth.getUser();
       if (!user) throw new Error("Not authenticated");
-      
-      const { data, error } = await supabase
-        .from("user_roles")
-        .select("role")
-        .eq("user_id", user.id);
-      
-      if (error) throw error;
-      return data;
+      return hasRole(user.id, "admin");
     },
   });
 
@@ -56,7 +50,6 @@ const AdminDashboard: React.FC = () => {
     return <div className="flex justify-center items-center h-screen">Loading...</div>;
   }
 
-  const isAdmin = userRoles?.some(role => role.role === "admin");
   if (!isAdmin) {
     return <Navigate to="/" replace />;
   }

--- a/src/utils/roles.ts
+++ b/src/utils/roles.ts
@@ -1,0 +1,17 @@
+import { supabase } from "@/integrations/supabase/client";
+import type { Database } from "@/integrations/supabase/types";
+
+export async function hasRole(
+  userId: string,
+  role: Database["public"]["Enums"]["app_role"]
+): Promise<boolean> {
+  const { data, error } = await supabase.rpc('has_role', {
+    _user_id: userId,
+    _role: role
+  });
+  if (error) {
+    console.error('[hasRole] Error checking role:', error);
+    return false;
+  }
+  return !!data;
+}

--- a/supabase/functions/_shared/roles.ts
+++ b/supabase/functions/_shared/roles.ts
@@ -1,0 +1,16 @@
+import { SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+export async function isAdmin(
+  supabase: SupabaseClient,
+  userId: string
+): Promise<boolean> {
+  const { data, error } = await supabase.rpc('has_role', {
+    _user_id: userId,
+    _role: 'admin'
+  })
+  if (error) {
+    console.error('[isAdmin] role check failed:', error)
+    return false
+  }
+  return !!data
+}

--- a/supabase/functions/admin-create-user/index.ts
+++ b/supabase/functions/admin-create-user/index.ts
@@ -1,6 +1,7 @@
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { isAdmin } from '../_shared/roles.ts'
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -34,14 +35,9 @@ serve(async (req) => {
     }
 
     // Check if user has admin role
-    const { data: userRoles, error: roleError } = await supabaseClient
-      .from('user_roles')
-      .select('role')
-      .eq('user_id', user.id)
-      .eq('role', 'admin')
-      .single()
+    const isAdminUser = await isAdmin(supabaseClient, user.id)
 
-    if (roleError || !userRoles) {
+    if (!isAdminUser) {
       console.log('[admin-create-user] User is not admin:', user.id)
       return new Response(JSON.stringify({ error: 'Access denied - Admin role required' }), {
         status: 403,

--- a/supabase/functions/admin-update-user/index.ts
+++ b/supabase/functions/admin-update-user/index.ts
@@ -1,6 +1,7 @@
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { isAdmin } from '../_shared/roles.ts'
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -34,14 +35,9 @@ serve(async (req) => {
     }
 
     // Check if user has admin role
-    const { data: userRoles, error: roleError } = await supabaseClient
-      .from('user_roles')
-      .select('role')
-      .eq('user_id', user.id)
-      .eq('role', 'admin')
-      .single()
+    const isAdminUser = await isAdmin(supabaseClient, user.id)
 
-    if (roleError || !userRoles) {
+    if (!isAdminUser) {
       console.log('[admin-update-user] User is not admin:', user.id)
       return new Response(JSON.stringify({ error: 'Access denied - Admin role required' }), {
         status: 403,


### PR DESCRIPTION
## Summary
- add helpers for checking roles
- use `has_role` RPC in UI components
- check admin rights in Cloud Functions with `isAdmin`

## Testing
- `npm test` *(fails: Database error)*

------
https://chatgpt.com/codex/tasks/task_e_68526970b96083209985848ea4d2473c