### PR TITLE
Fix imports and seo data handler

### DIFF
--- a/src/components/admin/ContentQualityIndicator.tsx
+++ b/src/components/admin/ContentQualityIndicator.tsx
@@ -3,7 +3,12 @@ import React from "react";
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
 import { AlertCircle, CheckCircle, Info } from "lucide-react";
-import { ContentQualityMetrics } from "@/services/ContentGenerationService";
+import type { ContentQuality } from "@/services/ContentGenerationService";
+
+export interface ContentQualityMetrics extends ContentQuality {
+  seoScore?: number;
+  issues?: string[];
+}
 
 interface ContentQualityIndicatorProps {
   quality: ContentQualityMetrics;

--- a/src/components/admin/EditBlogPostModal.tsx
+++ b/src/components/admin/EditBlogPostModal.tsx
@@ -283,7 +283,7 @@ const EditBlogPostModal: React.FC<EditBlogPostModalProps> = ({ post, onClose, on
               excerpt={formData.excerpt}
               category={formData.category}
               featuredImage={formData.featured_image}
-              onSEODataChange={setSeoData}
+              onSEODataChange={(data) => setSeoData(data as SEOMetadata)}
             />
           </div>
         </div>

--- a/src/components/admin/EnhancedBlogArticleEditor.tsx
+++ b/src/components/admin/EnhancedBlogArticleEditor.tsx
@@ -285,7 +285,7 @@ const EnhancedBlogArticleEditor: React.FC<EnhancedBlogArticleEditorProps> = ({
             category={category}
             tags={tags}
             featuredImage={generatedContent.featuredImage}
-            onSEODataChange={setSeoData}
+            onSEODataChange={(data) => setSeoData(data as SEOMetadata)}
           />
 
           {showPreview ? (

--- a/src/components/admin/PersonalizedContentGenerator.tsx
+++ b/src/components/admin/PersonalizedContentGenerator.tsx
@@ -58,8 +58,7 @@ const PersonalizedContentGenerator: React.FC = () => {
       const result = await contentGenerationService.generateBlogPost({
         prompt: personalizedPrompt,
         category: profile.preferredCategories[0],
-        audiences: [profile.skillLevel],
-        retries: 2
+        audiences: [profile.skillLevel]
       });
 
       setGeneratedContent(result.content);

--- a/src/services/ContentGenerationService.ts
+++ b/src/services/ContentGenerationService.ts
@@ -199,3 +199,5 @@ export class ContentGenerationService {
     return data.imageUrl;
   }
 }
+
+export const contentGenerationService = ContentGenerationService.getInstance();


### PR DESCRIPTION
## Summary
- export a singleton `contentGenerationService`
- adjust ContentQualityIndicator type import
- handle SEO data change correctly in editors
- make issues optional in quality metrics
- remove retries option and unused type export

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*
- `npx tsc -p tsconfig.app.json` *(fails: missing peer deps like react/jsx-runtime)*

------
https://chatgpt.com/codex/tasks/task_e_6855098a0bfc8320b425f1bb50a2e02a