### PR TITLE
Fix missing module errors in create-strategy-article

### DIFF
--- a/supabase/functions/create-strategy-article/helpers.ts
+++ b/supabase/functions/create-strategy-article/helpers.ts
@@ -1,0 +1,17 @@
+
+export function generateSlug(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/ä/g, 'ae')
+    .replace(/ö/g, 'oe')
+    .replace(/ü/g, 'ue')
+    .replace(/ß/g, 'ss')
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+export function getRandom(arr: any[]) {
+  return arr[Math.floor(Math.random() * arr.length)];
+}

--- a/supabase/functions/create-strategy-article/index.ts
+++ b/supabase/functions/create-strategy-article/index.ts
@@ -2,9 +2,9 @@ import "https://deno.land/x/xhr@0.1.0/mod.ts";
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.5";
 import { buildMariannePrompt } from "./marianne-style.ts";
-import { generateSlug, getRandom } from "../auto-blog-post/helpers.ts";
-import { generateImage, generateArticle } from "../auto-blog-post/openai.ts";
-import { uploadImageToSupabase, saveBlogPost } from "../auto-blog-post/supabase-helpers.ts";
+import { generateSlug, getRandom } from "./helpers.ts";
+import { generateImage, generateArticle } from "./openai.ts";
+import { uploadImageToSupabase, saveBlogPost } from "./supabase-helpers.ts";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL");
 const SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");

--- a/supabase/functions/create-strategy-article/openai.ts
+++ b/supabase/functions/create-strategy-article/openai.ts
@@ -1,0 +1,202 @@
+
+const OPENAI_API_KEY = Deno.env.get("OPENAI_API_KEY");
+const OPENAI_ADMIN_KEY = Deno.env.get("OPENAI_ADMIN_KEY");
+
+// Use admin key for enhanced capabilities, fallback to regular key
+const getOpenAIKey = (requireAdmin = false) => {
+  if (requireAdmin && OPENAI_ADMIN_KEY) {
+    return OPENAI_ADMIN_KEY;
+  }
+  return OPENAI_ADMIN_KEY || OPENAI_API_KEY;
+};
+
+export async function generateImage({ theme, category, season, trend }: { theme: string, category: string, season: string, trend: string }) {
+  const apiKey = getOpenAIKey(true); // Use admin key for image generation
+  
+  if (!apiKey) {
+    throw new Error("OpenAI API-Schlüssel nicht konfiguriert");
+  }
+
+  const basePrompt = `Hyperrealistisches, stimmungsvolles Garten- oder Küchenbild passend zum Thema "${theme}" (${category}, ${season}, Trend: ${trend}). Natürliches Licht, viel Atmosphäre, hochwertiger Fotografie-Stil. Ohne Text.`;
+  
+  try {
+    const response = await fetch("https://api.openai.com/v1/images/generations", {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "gpt-image-1", // Use the latest image model
+        prompt: basePrompt,
+        n: 1,
+        size: "1024x1024",
+        response_format: "b64_json",
+        quality: "high", // Enhanced quality with admin key
+        output_format: "png",
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`OpenAI API Fehler (${response.status}): ${errorText}`);
+    }
+
+    const data = await response.json();
+    
+    if (!data.data?.[0]?.b64_json) {
+      throw new Error("Bildgenerierung fehlgeschlagen - keine Bilddaten erhalten");
+    }
+    
+    return data.data[0].b64_json;
+  } catch (error) {
+    console.error("Bildgenerierung Fehler:", error);
+    throw new Error(`Bildgenerierung fehlgeschlagen: ${error.message}`);
+  }
+}
+
+export async function generateTopicIdea(contextPrompt: string) {
+  const apiKey = getOpenAIKey();
+  
+  if (!apiKey) {
+    throw new Error("OpenAI API-Schlüssel nicht konfiguriert");
+  }
+
+  try {
+    const ideaResp = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "gpt-4.1-2025-04-14", // Latest model
+        messages: [
+          { role: "system", content: "Du bist eine deutschsprachige Garten-/Küchenbloggerin. Erfinde ein frisches, trendiges Blogartikel-Thema für diese Rahmenbedingungen (höchstens 10 Worte):" },
+          { role: "user", content: contextPrompt }
+        ],
+        temperature: 0.85,
+        max_tokens: 64,
+      }),
+    });
+
+    if (!ideaResp.ok) {
+      const errorText = await ideaResp.text();
+      throw new Error(`OpenAI API Fehler (${ideaResp.status}): ${errorText}`);
+    }
+
+    const ideaData = await ideaResp.json();
+    return (
+      ideaData.choices?.[0]?.message?.content?.replace(/[".]/g, "").trim() ||
+      "Neuer Blogartikel"
+    );
+  } catch (error) {
+    console.error("Topic-Generierung Fehler:", error);
+    throw new Error(`Topic-Generierung fehlgeschlagen: ${error.message}`);
+  }
+}
+
+export async function generateArticle(prompt: string) {
+  const apiKey = getOpenAIKey(true); // Use admin key for enhanced article generation
+  
+  if (!apiKey) {
+    throw new Error("OpenAI API-Schlüssel nicht konfiguriert");
+  }
+
+  try {
+    const artResp = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "gpt-4.1-2025-04-14", // Latest model
+        messages: [
+          { role: "system", content: "Du bist eine deutsche Garten-/Küchenbloggerin. Gib einen SEO-optimierten Artikel als Markdown zurück, mit Überschrift und Teaser." },
+          { role: "user", content: prompt }
+        ],
+        temperature: 0.75,
+        max_tokens: 2500, // Increased for better content
+      }),
+    });
+
+    if (!artResp.ok) {
+      const errorText = await artResp.text();
+      throw new Error(`OpenAI API Fehler (${artResp.status}): ${errorText}`);
+    }
+
+    const artData = await artResp.json();
+    
+    if (!artData.choices?.[0]?.message?.content) {
+      throw new Error("Artikel-Generierung fehlgeschlagen - kein Content erhalten");
+    }
+    
+    return artData.choices[0].message.content.trim();
+  } catch (error) {
+    console.error("Artikel-Generierung Fehler:", error);
+    throw new Error(`Artikel-Generierung fehlgeschlagen: ${error.message}`);
+  }
+}
+
+// New admin-level function for content analysis and optimization
+export async function analyzeContentPerformance(content: string, metadata: any) {
+  const apiKey = getOpenAIKey(true); // Requires admin key
+  
+  if (!apiKey) {
+    throw new Error("OpenAI Admin-Schlüssel erforderlich für Content-Analyse");
+  }
+
+  try {
+    const response = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "gpt-4.1-2025-04-14",
+        messages: [
+          { 
+            role: "system", 
+            content: "Du bist ein SEO- und Content-Marketing-Experte. Analysiere den gegebenen Content und gib konkrete Verbesserungsvorschläge. Antworte als JSON mit den Feldern: seoScore (0-100), readabilityScore (0-100), engagementPotential (0-100), improvements (Array von Strings), keywords (Array), estimatedPerformance (0-100)." 
+          },
+          { 
+            role: "user", 
+            content: `Analysiere diesen Content:\n\nTitel: ${metadata.title}\nKategorie: ${metadata.category}\nContent: ${content.substring(0, 2000)}...` 
+          }
+        ],
+        temperature: 0.3,
+        max_tokens: 1000,
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`OpenAI API Fehler: ${response.status}`);
+    }
+
+    const data = await response.json();
+    const analysisText = data.choices?.[0]?.message?.content;
+    
+    if (!analysisText) {
+      throw new Error("Keine Analyse erhalten");
+    }
+
+    // Try to parse as JSON, fallback to structured text
+    try {
+      return JSON.parse(analysisText);
+    } catch {
+      return {
+        seoScore: 75,
+        readabilityScore: 80,
+        engagementPotential: 70,
+        improvements: [analysisText],
+        keywords: [],
+        estimatedPerformance: 75
+      };
+    }
+  } catch (error) {
+    console.error("Content-Analyse Fehler:", error);
+    throw error;
+  }
+}

--- a/supabase/functions/create-strategy-article/supabase-helpers.ts
+++ b/supabase/functions/create-strategy-article/supabase-helpers.ts
@@ -1,0 +1,106 @@
+
+// Helper für Supabase-Operationen beim Auto-Blog-Post
+import { SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2.39.5";
+
+/**
+ * Stellt fest, ob ein Slug oder Titel bereits in der kompletten History vorhanden ist.
+ * Optionale fuzzy Logik: auch Titel-Ähnlichkeit ab 85% als Duplikat zählen.
+ */
+export async function isDuplicate(supabase: SupabaseClient, slug: string, title: string) {
+  // Prüfe Slug
+  const { data: histSlugs, error: hSlugErr } = await supabase
+    .from("blog_topic_history")
+    .select("slug, title");
+
+  if (hSlugErr) {
+    console.error("Fehler beim Lesen der topic_history:", hSlugErr);
+    throw new Error(`Fehler beim Lesen der History: ${hSlugErr.message}`);
+  }
+
+  // Slug exakte Übereinstimmung (mit Suffix-Entfernung)
+  const baseSlug = slug.replace(/-\d+$/, "");
+  let found = histSlugs?.some((t: any) => t.slug.replace(/-\d+$/, "") === baseSlug);
+
+  // Titel exakt
+  if (!found && title) {
+    found = histSlugs?.some((t: any) => t.title.trim().toLowerCase() === title.trim().toLowerCase());
+  }
+  // Fuzzy Title Check (min 85% Ähnlichkeit, einfachster Ansatz: Levenshtein)
+  if (!found && title) {
+    found = histSlugs?.some((t: any) => {
+      const a = normalize(title), b = normalize(t.title || "");
+      return a.length > 4 && b.length > 4 && levenshtein(a, b) / Math.max(a.length, b.length) > 0.85;
+    });
+  }
+
+  return found;
+}
+
+// Normalisiert Zeichen für Fuzzy-Vergleich
+function normalize(str: string) {
+  return str.toLowerCase().replace(/[äöüß]/g, c =>
+    ({'ä':'ae','ö':'oe','ü':'ue','ß':'ss'}[c]||c)
+  ).replace(/[^a-z0-9]/g,'').trim();
+}
+
+// Einfache Levenshtein-Distanz (liefert Zahl der gleichen Zeichen am ANFANG)
+function levenshtein(a: string, b: string) {
+  let i = 0;
+  const max = Math.min(a.length, b.length);
+  while (i < max && a[i] === b[i]) i++;
+  return i;
+}
+
+export async function checkBlacklist(supabase: SupabaseClient, topicIdea: string) {
+    const { data: blacklist, error: blacklistError } = await supabase
+      .from("blog_topic_blacklist")
+      .select("topic");
+    if (blacklistError) {
+      console.error("Fehler beim Laden der Blacklist:", blacklistError.message);
+      return false;
+    }
+    if (blacklist?.length) {
+      const isBlacklisted = blacklist.some((item: any) =>
+        topicIdea.toLowerCase().includes(item.topic.toLowerCase())
+      );
+      return isBlacklisted;
+    }
+    return false;
+}
+
+export async function saveBlogPost(supabase: SupabaseClient, postData: any) {
+    const { error } = await supabase.from("blog_posts").insert([postData]);
+    if (error) {
+        console.error("Fehler beim Einfügen:", error);
+        throw new Error(`Fehler beim Einfügen: ${error.message}`);
+    }
+}
+
+export async function uploadImageToSupabase({ supabase, imageB64, fileName }: { supabase: SupabaseClient, imageB64: string, fileName: string }) {
+  const binary = Uint8Array.from(atob(imageB64), c => c.charCodeAt(0));
+  const { error } = await supabase
+    .storage
+    .from("blog-images")
+    .upload(fileName, binary, {
+      contentType: "image/png",
+      upsert: true,
+    });
+  if (error) throw new Error("Bilder-Upload fehlgeschlagen: " + error.message);
+
+  const { data } = supabase
+    .storage
+    .from("blog-images")
+    .getPublicUrl(fileName);
+
+  return data.publicUrl;
+}
+
+// Für Logging von Themenversuchen (Punkt 1.1)
+export async function logTopicAttempt(supabase: SupabaseClient, { slug, title, used_in_post, reason, try_count, context }: any) {
+    const { error } = await supabase.from("blog_topic_history").insert([{
+      slug, title, used_in_post: used_in_post || null, reason, try_count: try_count || 1, context: context ? JSON.stringify(context) : null
+    }]);
+    if (error) {
+      console.error("Fehler beim Protokollieren des Themas:", error);
+    }
+}


### PR DESCRIPTION
## Summary
- add helper modules for `create-strategy-article`
- update imports to reference local copies

## Testing
- `npm test` *(fails: vitest not found)*
- `supabase functions deploy create-strategy-article` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68569e270de48320a663d1af78514514

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added advanced AI-powered tools for generating images, blog topics, and SEO-optimized articles in German.
	- Introduced content performance analysis with actionable suggestions.
	- Implemented duplicate detection and blacklist checks for blog topics.
	- Enabled direct image uploads and blog post saving to the platform.
	- Enhanced logging for blog topic creation attempts.

- **Chores**
	- Improved internal module organization for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->