### PR TITLE
Update OpenAI models to gpt-4o

### DIFF
--- a/supabase/functions/ai-content-insights/index.ts
+++ b/supabase/functions/ai-content-insights/index.ts
@@ -62,7 +62,7 @@ async function analyzeContentPerformance(contentData: any, supabase: any) {
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      model: "gpt-4.1-2025-04-14",
+      model: "gpt-4o",
       messages: [
         {
           role: "system",
@@ -124,7 +124,7 @@ async function generateContentInsights(supabase: any) {
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      model: "gpt-4.1-2025-04-14",
+      model: "gpt-4o",
       messages: [
         {
           role: "system",
@@ -173,7 +173,7 @@ async function predictContentTrends(supabase: any) {
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      model: "gpt-4.1-2025-04-14",
+      model: "gpt-4o",
       messages: [
         {
           role: "system",
@@ -226,7 +226,7 @@ async function optimizeContent(contentData: any, supabase: any) {
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      model: "gpt-4.1-2025-04-14",
+      model: "gpt-4o",
       messages: [
         {
           role: "system",

--- a/supabase/functions/create-strategy-article/helpers.ts
+++ b/supabase/functions/create-strategy-article/helpers.ts
@@ -1,0 +1,17 @@
+
+export function generateSlug(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/ä/g, 'ae')
+    .replace(/ö/g, 'oe')
+    .replace(/ü/g, 'ue')
+    .replace(/ß/g, 'ss')
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+export function getRandom(arr: any[]) {
+  return arr[Math.floor(Math.random() * arr.length)];
+}

--- a/supabase/functions/create-strategy-article/index.ts
+++ b/supabase/functions/create-strategy-article/index.ts
@@ -2,9 +2,9 @@ import "https://deno.land/x/xhr@0.1.0/mod.ts";
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.5";
 import { buildMariannePrompt } from "./marianne-style.ts";
-import { generateSlug, getRandom } from "../auto-blog-post/helpers.ts";
-import { generateImage, generateArticle } from "../auto-blog-post/openai.ts";
-import { uploadImageToSupabase, saveBlogPost } from "../auto-blog-post/supabase-helpers.ts";
+import { generateSlug, getRandom } from "./helpers.ts";
+import { generateImage, generateArticle } from "./openai.ts";
+import { uploadImageToSupabase, saveBlogPost } from "./supabase-helpers.ts";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL");
 const SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");

--- a/supabase/functions/create-strategy-article/openai.ts
+++ b/supabase/functions/create-strategy-article/openai.ts
@@ -156,6 +156,7 @@ export async function analyzeContentPerformance(content: string, metadata: any) 
       },
       body: JSON.stringify({
         model: "gpt-4o",
+        response_format: { type: "json_object" },
         messages: [
           { 
             role: "system", 

--- a/supabase/functions/create-strategy-article/supabase-helpers.ts
+++ b/supabase/functions/create-strategy-article/supabase-helpers.ts
@@ -1,0 +1,106 @@
+
+// Helper für Supabase-Operationen beim Auto-Blog-Post
+import { SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2.39.5";
+
+/**
+ * Stellt fest, ob ein Slug oder Titel bereits in der kompletten History vorhanden ist.
+ * Optionale fuzzy Logik: auch Titel-Ähnlichkeit ab 85% als Duplikat zählen.
+ */
+export async function isDuplicate(supabase: SupabaseClient, slug: string, title: string) {
+  // Prüfe Slug
+  const { data: histSlugs, error: hSlugErr } = await supabase
+    .from("blog_topic_history")
+    .select("slug, title");
+
+  if (hSlugErr) {
+    console.error("Fehler beim Lesen der topic_history:", hSlugErr);
+    throw new Error(`Fehler beim Lesen der History: ${hSlugErr.message}`);
+  }
+
+  // Slug exakte Übereinstimmung (mit Suffix-Entfernung)
+  const baseSlug = slug.replace(/-\d+$/, "");
+  let found = histSlugs?.some((t: any) => t.slug.replace(/-\d+$/, "") === baseSlug);
+
+  // Titel exakt
+  if (!found && title) {
+    found = histSlugs?.some((t: any) => t.title.trim().toLowerCase() === title.trim().toLowerCase());
+  }
+  // Fuzzy Title Check (min 85% Ähnlichkeit, einfachster Ansatz: Levenshtein)
+  if (!found && title) {
+    found = histSlugs?.some((t: any) => {
+      const a = normalize(title), b = normalize(t.title || "");
+      return a.length > 4 && b.length > 4 && levenshtein(a, b) / Math.max(a.length, b.length) > 0.85;
+    });
+  }
+
+  return found;
+}
+
+// Normalisiert Zeichen für Fuzzy-Vergleich
+function normalize(str: string) {
+  return str.toLowerCase().replace(/[äöüß]/g, c =>
+    ({'ä':'ae','ö':'oe','ü':'ue','ß':'ss'}[c]||c)
+  ).replace(/[^a-z0-9]/g,'').trim();
+}
+
+// Einfache Levenshtein-Distanz (liefert Zahl der gleichen Zeichen am ANFANG)
+function levenshtein(a: string, b: string) {
+  let i = 0;
+  const max = Math.min(a.length, b.length);
+  while (i < max && a[i] === b[i]) i++;
+  return i;
+}
+
+export async function checkBlacklist(supabase: SupabaseClient, topicIdea: string) {
+    const { data: blacklist, error: blacklistError } = await supabase
+      .from("blog_topic_blacklist")
+      .select("topic");
+    if (blacklistError) {
+      console.error("Fehler beim Laden der Blacklist:", blacklistError.message);
+      return false;
+    }
+    if (blacklist?.length) {
+      const isBlacklisted = blacklist.some((item: any) =>
+        topicIdea.toLowerCase().includes(item.topic.toLowerCase())
+      );
+      return isBlacklisted;
+    }
+    return false;
+}
+
+export async function saveBlogPost(supabase: SupabaseClient, postData: any) {
+    const { error } = await supabase.from("blog_posts").insert([postData]);
+    if (error) {
+        console.error("Fehler beim Einfügen:", error);
+        throw new Error(`Fehler beim Einfügen: ${error.message}`);
+    }
+}
+
+export async function uploadImageToSupabase({ supabase, imageB64, fileName }: { supabase: SupabaseClient, imageB64: string, fileName: string }) {
+  const binary = Uint8Array.from(atob(imageB64), c => c.charCodeAt(0));
+  const { error } = await supabase
+    .storage
+    .from("blog-images")
+    .upload(fileName, binary, {
+      contentType: "image/png",
+      upsert: true,
+    });
+  if (error) throw new Error("Bilder-Upload fehlgeschlagen: " + error.message);
+
+  const { data } = supabase
+    .storage
+    .from("blog-images")
+    .getPublicUrl(fileName);
+
+  return data.publicUrl;
+}
+
+// Für Logging von Themenversuchen (Punkt 1.1)
+export async function logTopicAttempt(supabase: SupabaseClient, { slug, title, used_in_post, reason, try_count, context }: any) {
+    const { error } = await supabase.from("blog_topic_history").insert([{
+      slug, title, used_in_post: used_in_post || null, reason, try_count: try_count || 1, context: context ? JSON.stringify(context) : null
+    }]);
+    if (error) {
+      console.error("Fehler beim Protokollieren des Themas:", error);
+    }
+}

--- a/supabase/functions/generate-blog-post/index.ts
+++ b/supabase/functions/generate-blog-post/index.ts
@@ -149,7 +149,7 @@ FORMAT: Reines Markdown ohne Metadaten-Block, perfekt für moderne CMS-Systeme.`
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
-        model: "gpt-4.1-2025-04-14", // Latest model for 2025
+        model: "gpt-4o",
         messages,
         temperature: 0.7,
         max_tokens: 4000, // Increased for longer, more detailed articles
@@ -243,7 +243,7 @@ FORMAT: Reines Markdown ohne Metadaten-Block, perfekt für moderne CMS-Systeme.`
           h3Count: hasH3Headings,
           listCount: hasLists,
           hasFAQ,
-          model: "gpt-4.1-2025-04-14",
+          model: "gpt-4o",
           enhancedFeatures: true,
           aiCapabilities: "admin-level",
           timestamp: new Date().toISOString()


### PR DESCRIPTION
## Summary
- switch all Supabase functions from `gpt-4.1-2025-04-14` to `gpt-4o`
- ensure `analyzeContentPerformance` requests structured JSON

## Testing
- `npm test` *(fails: vitest not found)*
- `supabase functions deploy create-strategy-article` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68569e270de48320a663d1af78514514