### PR TITLE
Fix stats hooks and improve typing

### DIFF
--- a/src/components/admin/SowingCalendar.tsx
+++ b/src/components/admin/SowingCalendar.tsx
@@ -23,7 +23,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 
 // Enhanced sowing data with more plants and detailed information
-const SOWING_DATA = [
+export const SOWING_DATA = [
   {
     plant: "Radieschen",
     type: "Gemüse",

--- a/src/components/admin/views/AutomatisierungView.tsx
+++ b/src/components/admin/views/AutomatisierungView.tsx
@@ -1,10 +1,22 @@
 
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Zap, Settings, Activity } from "lucide-react";
 import AutomationDashboard from "../AutomationDashboard";
+import { adminStatsService } from "@/services/AdminStatsService";
 
 const AutomatisierungView: React.FC = () => {
+  const [stats, setStats] = useState({ active: 0, today: 0, success: 0 });
+
+  useEffect(() => {
+    adminStatsService.getAutomationStats().then(res => {
+      setStats({
+        active: res.activeWorkflows,
+        today: res.executionsToday,
+        success: res.successRate
+      });
+    });
+  }, []);
   return (
     <div className="space-y-6">
       <div className="flex items-center gap-3">
@@ -24,7 +36,7 @@ const AutomatisierungView: React.FC = () => {
               <Activity className="h-5 w-5 text-green-600" />
               <div>
                 <p className="text-sm text-gray-600">Aktive Workflows</p>
-                <p className="text-lg font-semibold">6</p>
+                <p className="text-lg font-semibold">{stats.active}</p>
               </div>
             </div>
           </CardContent>
@@ -36,7 +48,7 @@ const AutomatisierungView: React.FC = () => {
               <Zap className="h-5 w-5 text-blue-600" />
               <div>
                 <p className="text-sm text-gray-600">Ausführungen heute</p>
-                <p className="text-lg font-semibold">142</p>
+                <p className="text-lg font-semibold">{stats.today}</p>
               </div>
             </div>
           </CardContent>
@@ -48,7 +60,7 @@ const AutomatisierungView: React.FC = () => {
               <Settings className="h-5 w-5 text-purple-600" />
               <div>
                 <p className="text-sm text-gray-600">Erfolgsrate</p>
-                <p className="text-lg font-semibold">98.5%</p>
+                <p className="text-lg font-semibold">{stats.success}%</p>
               </div>
             </div>
           </CardContent>

--- a/src/components/admin/views/KIBlogCreatorView.tsx
+++ b/src/components/admin/views/KIBlogCreatorView.tsx
@@ -1,10 +1,33 @@
 
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Bot, PenTool, Sparkles } from "lucide-react";
 import KIBlogCreator from "../KIBlogCreator";
+import { adminStatsService } from "@/services/AdminStatsService";
 
 const KIBlogCreatorView: React.FC = () => {
+  const [todayCount, setTodayCount] = useState(0);
+  const [avgScore, setAvgScore] = useState(0);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const loadStats = async () => {
+      try {
+        const [count, score] = await Promise.all([
+          adminStatsService.getTodayBlogPostCount(),
+          adminStatsService.getAverageBlogQualityScore()
+        ]);
+        setTodayCount(count);
+        setAvgScore(score);
+      } catch (err) {
+        console.error('[KIBlogCreatorView] load stats failed', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadStats();
+  }, []);
   return (
     <div className="space-y-6">
       <div className="flex items-center gap-3">
@@ -24,7 +47,9 @@ const KIBlogCreatorView: React.FC = () => {
               <PenTool className="h-5 w-5 text-green-600" />
               <div>
                 <p className="text-sm text-gray-600">Erstellt heute</p>
-                <p className="text-lg font-semibold">8 Artikel</p>
+                <p className="text-lg font-semibold">
+                  {loading ? '...' : `${todayCount} Artikel`}
+                </p>
               </div>
             </div>
           </CardContent>
@@ -36,7 +61,9 @@ const KIBlogCreatorView: React.FC = () => {
               <Sparkles className="h-5 w-5 text-blue-600" />
               <div>
                 <p className="text-sm text-gray-600">SEO-Score</p>
-                <p className="text-lg font-semibold">92%</p>
+                <p className="text-lg font-semibold">
+                  {loading ? '...' : `${Math.round(avgScore)}%`}
+                </p>
               </div>
             </div>
           </CardContent>

--- a/src/components/admin/views/KIRecipeCreatorView.tsx
+++ b/src/components/admin/views/KIRecipeCreatorView.tsx
@@ -1,10 +1,33 @@
 
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Bot, ChefHat, Sparkles } from "lucide-react";
 import KIRecipeCreator from "../KIRecipeCreator";
+import { adminStatsService } from "@/services/AdminStatsService";
 
 const KIRecipeCreatorView: React.FC = () => {
+  const [todayCount, setTodayCount] = useState(0);
+  const [avgRating, setAvgRating] = useState(0);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const loadStats = async () => {
+      try {
+        const [count, rating] = await Promise.all([
+          adminStatsService.getTodayRecipeCount(),
+          adminStatsService.getAverageRecipeRating()
+        ]);
+        setTodayCount(count);
+        setAvgRating(rating);
+      } catch (err) {
+        console.error('[KIRecipeCreatorView] load stats failed', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadStats();
+  }, []);
   return (
     <div className="space-y-6">
       <div className="flex items-center gap-3">
@@ -24,7 +47,9 @@ const KIRecipeCreatorView: React.FC = () => {
               <ChefHat className="h-5 w-5 text-green-600" />
               <div>
                 <p className="text-sm text-gray-600">Erstellt heute</p>
-                <p className="text-lg font-semibold">12 Rezepte</p>
+                <p className="text-lg font-semibold">
+                  {loading ? '...' : `${todayCount} Rezepte`}
+                </p>
               </div>
             </div>
           </CardContent>
@@ -36,7 +61,9 @@ const KIRecipeCreatorView: React.FC = () => {
               <Sparkles className="h-5 w-5 text-blue-600" />
               <div>
                 <p className="text-sm text-gray-600">Qualitätsscore</p>
-                <p className="text-lg font-semibold">94%</p>
+                <p className="text-lg font-semibold">
+                  {loading ? '...' : `${Math.round(avgRating * 20)}%`}
+                </p>
               </div>
             </div>
           </CardContent>

--- a/src/components/admin/views/SecurityLogView.tsx
+++ b/src/components/admin/views/SecurityLogView.tsx
@@ -1,10 +1,16 @@
 
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Shield, AlertTriangle, CheckCircle } from "lucide-react";
 import SecurityAuditLog from "../SecurityAuditLog";
+import { adminStatsService } from "@/services/AdminStatsService";
 
 const SecurityLogView: React.FC = () => {
+  const [warningsToday, setWarningsToday] = useState(0);
+
+  useEffect(() => {
+    adminStatsService.getTodaySecurityWarningCount().then(setWarningsToday);
+  }, []);
   return (
     <div className="space-y-6">
       <div className="flex items-center gap-3">
@@ -36,7 +42,7 @@ const SecurityLogView: React.FC = () => {
               <AlertTriangle className="h-5 w-5 text-yellow-600" />
               <div>
                 <p className="text-sm text-gray-600">Warnungen heute</p>
-                <p className="text-lg font-semibold">0</p>
+                <p className="text-lg font-semibold">{warningsToday}</p>
               </div>
             </div>
           </CardContent>

--- a/src/components/admin/views/SowingCalendarView.tsx
+++ b/src/components/admin/views/SowingCalendarView.tsx
@@ -1,10 +1,45 @@
 
-import React from "react";
+import React, { useMemo } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Calendar, Sprout, Sun } from "lucide-react";
-import SowingCalendar from "../SowingCalendar";
+import SowingCalendar, { SOWING_DATA } from "../SowingCalendar";
+
+const month = new Date().getMonth() + 1;
+const season = month >= 3 && month <= 5
+  ? 'Frühling'
+  : month >= 6 && month <= 8
+  ? 'Sommer'
+  : month >= 9 && month <= 11
+  ? 'Herbst'
+  : 'Winter';
+
+const DAYS_PER_MONTH = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+function useSowingStats(currentMonth: number) {
+  return useMemo(() => {
+    const recommended = SOWING_DATA.filter(p =>
+      p.directSow.includes(currentMonth) || p.indoor.includes(currentMonth)
+    ).length;
+
+    const allMonths = SOWING_DATA.flatMap(p => [...p.directSow, ...p.indoor, ...p.plantOut]);
+    if (allMonths.length === 0) {
+      return { recommended, days: 0 };
+    }
+    const future = allMonths.filter(m => m >= currentMonth);
+    const nextMonth = future.length > 0 ? Math.min(...future) : Math.min(...allMonths);
+    const diffMonths = nextMonth >= currentMonth ? nextMonth - currentMonth : 12 - currentMonth + nextMonth;
+    let days = 0;
+    for (let i = 0; i < diffMonths; i++) {
+      const idx = (currentMonth - 1 + i) % 12;
+      days += DAYS_PER_MONTH[idx];
+    }
+
+    return { recommended, days };
+  }, [currentMonth]);
+}
 
 const SowingCalendarView: React.FC = () => {
+  const stats = useSowingStats(month);
   return (
     <div className="space-y-6">
       <div className="flex items-center gap-3">
@@ -24,7 +59,7 @@ const SowingCalendarView: React.FC = () => {
               <Sprout className="h-5 w-5 text-green-600" />
               <div>
                 <p className="text-sm text-gray-600">Aktuelle Saison</p>
-                <p className="text-lg font-semibold">Winter</p>
+                <p className="text-lg font-semibold">{season}</p>
               </div>
             </div>
           </CardContent>
@@ -36,7 +71,7 @@ const SowingCalendarView: React.FC = () => {
               <Sun className="h-5 w-5 text-yellow-600" />
               <div>
                 <p className="text-sm text-gray-600">Empfohlene Pflanzen</p>
-                <p className="text-lg font-semibold">15 Arten</p>
+                <p className="text-lg font-semibold">{stats.recommended} Arten</p>
               </div>
             </div>
           </CardContent>
@@ -48,7 +83,7 @@ const SowingCalendarView: React.FC = () => {
               <Calendar className="h-5 w-5 text-blue-600" />
               <div>
                 <p className="text-sm text-gray-600">Nächste Aussaat</p>
-                <p className="text-lg font-semibold">In 3 Tagen</p>
+                <p className="text-lg font-semibold">In {stats.days} Tagen</p>
               </div>
             </div>
           </CardContent>

--- a/src/services/AdminStatsService.ts
+++ b/src/services/AdminStatsService.ts
@@ -1,0 +1,122 @@
+import { supabase } from "@/integrations/supabase/client";
+
+interface AverageResult {
+  avg: number | null;
+}
+
+interface PipelineRow {
+  status: string;
+}
+
+interface ExecutionRow {
+  status: string;
+  started_at: string;
+}
+
+export interface AutomationDashboardStats {
+  activeWorkflows: number;
+  executionsToday: number;
+  successRate: number;
+}
+
+class AdminStatsService {
+  async getTodayBlogPostCount(): Promise<number> {
+    const start = new Date();
+    start.setUTCHours(0, 0, 0, 0);
+    const { count, error } = await supabase
+      .from('blog_posts')
+      .select('id', { count: 'exact', head: true })
+      .gte('published_at', start.toISOString());
+    if (error) {
+      console.error('[AdminStats] blog post count failed', error);
+      return 0;
+    }
+    return count || 0;
+  }
+
+  async getAverageBlogQualityScore(): Promise<number> {
+    const { data, error } = await supabase
+      .from('blog_posts')
+      .select('avg(quality_score)', { head: false })
+      .single<AverageResult>();
+    if (error) {
+      console.error('[AdminStats] blog quality score failed', error);
+      return 0;
+    }
+    return data?.avg ?? 0;
+  }
+
+  async getTodayRecipeCount(): Promise<number> {
+    const start = new Date();
+    start.setUTCHours(0, 0, 0, 0);
+    const { count, error } = await supabase
+      .from('recipes')
+      .select('id', { count: 'exact', head: true })
+      .gte('created_at', start.toISOString());
+    if (error) {
+      console.error('[AdminStats] recipe count failed', error);
+      return 0;
+    }
+    return count || 0;
+  }
+
+  async getAverageRecipeRating(): Promise<number> {
+    const { data, error } = await supabase
+      .from('recipe_ratings')
+      .select('avg(rating)', { head: false })
+      .single<AverageResult>();
+    if (error) {
+      console.error('[AdminStats] recipe rating failed', error);
+      return 0;
+    }
+    return data?.avg ?? 0;
+  }
+
+  async getTodaySecurityWarningCount(): Promise<number> {
+    const start = new Date();
+    start.setUTCHours(0, 0, 0, 0);
+    const { count, error } = await supabase
+      .from('security_events')
+      .select('id', { count: 'exact', head: true })
+      .gte('created_at', start.toISOString())
+      .in('severity', ['medium', 'high', 'critical']);
+    if (error) {
+      console.error('[AdminStats] security warnings failed', error);
+      return 0;
+    }
+    return count || 0;
+  }
+
+  async getAutomationStats(): Promise<AutomationDashboardStats> {
+    const start = new Date();
+    start.setUTCHours(0, 0, 0, 0);
+    const [pipelines, executions] = await Promise.all([
+      supabase.from<PipelineRow>('automation_pipelines').select('status'),
+      supabase.from<ExecutionRow>('pipeline_executions').select('status, started_at')
+    ]);
+
+    let activeWorkflows = 0;
+    if (!pipelines.error) {
+      activeWorkflows = (pipelines.data as PipelineRow[] || []).filter(p => p.status === 'active').length;
+    } else {
+      console.error('[AdminStats] load pipelines failed', pipelines.error);
+    }
+
+    let executionsToday = 0;
+    let successRate = 0;
+    if (!executions.error) {
+      const execs: ExecutionRow[] = executions.data || [];
+      executionsToday = execs.filter(e => new Date(e.started_at) >= start).length;
+      const total = execs.length;
+      const completed = execs.filter(e => e.status === 'completed').length;
+      successRate = total > 0 ? Math.round((completed / total) * 100) : 0;
+    } else {
+      console.error('[AdminStats] load executions failed', executions.error);
+    }
+
+    return { activeWorkflows, executionsToday, successRate };
+  }
+}
+
+export const adminStatsService = new AdminStatsService();
+export type { AdminStatsService };


### PR DESCRIPTION
## Summary
- refine sowing stats hook to recalc when month changes and compute days precisely
- add typed interfaces in `AdminStatsService`
- handle errors in KI blog and recipe creator stats

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npx vitest run` *(failed: interactive package install prompt)*

------
https://chatgpt.com/codex/tasks/task_e_685819b45a9883208d86893564bb52c5