### PR TITLE
Add debug login overlay with event logging

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,8 @@ import ErrorBoundary from '@/components/ErrorBoundary';
 import LazyRoute from '@/components/LazyRoute';
 import Layout from '@/components/Layout';
 import { useIsMobile } from '@/hooks/use-mobile';
+import { EventLoggerProvider } from '@/hooks/useEventLogger';
+import DebugOverlay from '@/components/DebugOverlay';
 
 // Lazy load components
 const Index = React.lazy(() => import('./pages/Index'));
@@ -43,10 +45,11 @@ function App() {
   return (
     <ErrorBoundary>
       <QueryClientProvider client={queryClient}>
-        <Router>
-          <Layout>
-            <Suspense fallback={<div className="flex items-center justify-center min-h-screen">Lädt...</div>}>
-              <Routes>
+        <EventLoggerProvider>
+          <Router>
+            <Layout>
+              <Suspense fallback={<div className="flex items-center justify-center min-h-screen">Lädt...</div>}>
+                <Routes>
                 <Route path="/" element={
                   <LazyRoute>
                     {isMobile ? <MobileLandingPage /> : <Index />}
@@ -71,8 +74,10 @@ function App() {
               </Routes>
             </Suspense>
           </Layout>
+          <DebugOverlay />
           <Toaster />
         </Router>
+        </EventLoggerProvider>
       </QueryClientProvider>
     </ErrorBoundary>
   );

--- a/src/components/DebugOverlay.tsx
+++ b/src/components/DebugOverlay.tsx
@@ -1,0 +1,83 @@
+import React, { useState } from 'react';
+import { useEventLogger } from '@/hooks/useEventLogger';
+import { supabase } from '@/integrations/supabase/client';
+
+const DebugOverlay: React.FC = () => {
+  const { logs, log } = useEventLogger();
+  const [open, setOpen] = useState(false);
+  const [form, setForm] = useState({ email: '', password: '' });
+  const [loading, setLoading] = useState(false);
+
+  const handleLogin = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    const { error } = await supabase.auth.signInWithPassword({
+      email: form.email,
+      password: form.password,
+    });
+    if (error) {
+      log(`LOGIN ERROR: ${error.message}`);
+    } else {
+      log('LOGIN SUCCESS');
+      setOpen(false);
+    }
+    setLoading(false);
+  };
+
+  return (
+    <>
+      <button
+        onClick={() => setOpen(o => !o)}
+        className="fixed bottom-4 right-4 z-50 bg-black text-white p-2 rounded"
+      >
+        Debug
+      </button>
+      {open && (
+        <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center">
+          <div className="bg-white w-full max-w-md rounded p-4 shadow-lg text-sm">
+            <h2 className="text-lg font-bold mb-2">Debug Login</h2>
+            <form onSubmit={handleLogin} className="space-y-2">
+              <input
+                type="email"
+                placeholder="email"
+                className="w-full border px-2 py-1"
+                value={form.email}
+                onChange={e => setForm({ ...form, email: e.target.value })}
+              />
+              <input
+                type="password"
+                placeholder="password"
+                className="w-full border px-2 py-1"
+                value={form.password}
+                onChange={e => setForm({ ...form, password: e.target.value })}
+              />
+              <button
+                type="submit"
+                disabled={loading}
+                className="w-full bg-sage-600 text-white py-1 rounded"
+              >
+                {loading ? '...' : 'Login'}
+              </button>
+            </form>
+            <div className="mt-4 flex justify-between items-center">
+              <span className="font-bold">Logs</span>
+              <button
+                className="underline"
+                onClick={() => navigator.clipboard.writeText(logs.join('\n'))}
+              >
+                Kopieren
+              </button>
+            </div>
+            <div className="mt-2 max-h-48 overflow-y-auto font-mono whitespace-pre-wrap border p-2">
+              {logs.map((l, i) => (
+                <div key={i}>{l}</div>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default DebugOverlay;

--- a/src/hooks/useEventLogger.tsx
+++ b/src/hooks/useEventLogger.tsx
@@ -1,0 +1,48 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+
+interface EventLoggerContextType {
+  logs: string[];
+  log: (msg: string) => void;
+}
+
+const EventLoggerContext = createContext<EventLoggerContextType | undefined>(undefined);
+
+export const EventLoggerProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [logs, setLogs] = useState<string[]>([]);
+  const log = (msg: string) => setLogs(prev => [...prev, `[${new Date().toISOString()}] ${msg}`]);
+
+  useEffect(() => {
+    const originalFetch = window.fetch;
+    window.fetch = async (...args) => {
+      log(`FETCH ${args[0]}`);
+      try {
+        const res = await originalFetch(...args);
+        log(`FETCH ${args[0]} -> ${res.status}`);
+        return res;
+      } catch (e: any) {
+        log(`FETCH ${args[0]} ERROR: ${e.message}`);
+        throw e;
+      }
+    };
+    const errorHandler = (e: ErrorEvent) => {
+      log(`ERROR ${e.message}`);
+    };
+    window.addEventListener('error', errorHandler);
+    return () => {
+      window.fetch = originalFetch;
+      window.removeEventListener('error', errorHandler);
+    };
+  }, []);
+
+  return (
+    <EventLoggerContext.Provider value={{ logs, log }}>
+      {children}
+    </EventLoggerContext.Provider>
+  );
+};
+
+export const useEventLogger = () => {
+  const ctx = useContext(EventLoggerContext);
+  if (!ctx) throw new Error('useEventLogger must be used within EventLoggerProvider');
+  return ctx;
+};


### PR DESCRIPTION
## Summary
- add event logger context that hooks into `fetch` and `window.error`
- create `DebugOverlay` component with login form and log display
- wrap app with `EventLoggerProvider` and place overlay globally

## Testing
- `npm ci`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6858faf5b6108320a3cbdffbffa68b09