### PR TITLE
Add global logging overlay

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -6,6 +6,7 @@ import Footer from './Footer';
 import GoogleAnalytics from './GoogleAnalytics';
 import AdSenseSlot from "./AdSenseSlot";
 import AdPlaceholder from "./AdPlaceholder";
+import LoggingOverlay from './LoggingOverlay';
 
 // Monetarisierung aus siteConfig
 const analyticsId = "G-ABCDE123456"; // <--- DEINE Google Analytics-ID hier eintragen!
@@ -62,6 +63,7 @@ const Layout: React.FC<LayoutProps> = ({
         </div>
       </main>
       <Footer />
+      <LoggingOverlay />
     </div>
   );
 };

--- a/src/components/LoggingOverlay.tsx
+++ b/src/components/LoggingOverlay.tsx
@@ -1,0 +1,61 @@
+import React, { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Sheet, SheetContent, SheetTrigger, SheetHeader, SheetTitle } from '@/components/ui/sheet';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import EventLogger from '@/services/EventLogger';
+import { Copy, Trash2 } from 'lucide-react';
+
+const logger = EventLogger.getInstance();
+
+const LoggingOverlay: React.FC = () => {
+  const [open, setOpen] = useState(false);
+  const [logs, setLogs] = useState<string[]>(logger.getLogs());
+
+  useEffect(() => {
+    return logger.subscribe(() => {
+      setLogs(logger.getLogs());
+    });
+  }, []);
+
+  const copyLogs = () => {
+    navigator.clipboard.writeText(logs.join('\n'));
+  };
+
+  const clearLogs = () => {
+    logger.clear();
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger asChild>
+        <Button
+          variant="secondary"
+          size="icon"
+          className="fixed bottom-4 right-4 z-50 shadow"
+        >
+          Log
+        </Button>
+      </SheetTrigger>
+      <SheetContent side="right" className="flex flex-col w-full sm:max-w-md p-0">
+        <SheetHeader className="flex justify-between items-center px-4 py-2 border-b">
+          <SheetTitle>Logs</SheetTitle>
+          <div className="flex gap-2">
+            <Button size="sm" variant="outline" onClick={copyLogs}>
+              <Copy className="w-4 h-4 mr-1" /> Kopieren
+            </Button>
+            <Button size="sm" variant="outline" onClick={clearLogs}>
+              <Trash2 className="w-4 h-4 mr-1" /> Leeren
+            </Button>
+          </div>
+        </SheetHeader>
+        <ScrollArea className="flex-1 p-4">
+          <pre className="text-xs whitespace-pre-wrap font-mono">
+            {logs.join('\n')}
+          </pre>
+        </ScrollArea>
+      </SheetContent>
+    </Sheet>
+  );
+};
+
+export default LoggingOverlay;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,10 +4,12 @@ import App from './App.tsx'
 import './index.css'
 import { applyColors } from './theme/colors'
 import PerformanceMonitor from './services/PerformanceMonitor'
+import EventLogger from './services/EventLogger'
 
 applyColors()
 
 // Initialize performance monitoring
 PerformanceMonitor.getInstance()
+EventLogger.getInstance()
 
 createRoot(document.getElementById("root")!).render(<App />);

--- a/src/services/EventLogger.ts
+++ b/src/services/EventLogger.ts
@@ -1,0 +1,75 @@
+import { format } from 'date-fns';
+
+interface LogEntry {
+  timestamp: number;
+  message: string;
+}
+
+class EventLogger {
+  private static instance: EventLogger;
+  private logs: LogEntry[] = [];
+  private emitter = new EventTarget();
+
+  private constructor() {
+    this.patchFetch();
+    this.patchErrors();
+  }
+
+  static getInstance(): EventLogger {
+    if (!EventLogger.instance) {
+      EventLogger.instance = new EventLogger();
+    }
+    return EventLogger.instance;
+  }
+
+  private patchFetch() {
+    if (typeof window === 'undefined' || !(window as any).fetch) return;
+    const originalFetch = window.fetch.bind(window);
+    window.fetch = async (...args) => {
+      this.log(`fetch ${args[0]}`);
+      try {
+        const response = await originalFetch(...args);
+        this.log(`response ${response.status} ${response.url}`);
+        return response;
+      } catch (e: any) {
+        this.log(`fetch error ${e?.message ?? e}`);
+        throw e;
+      }
+    };
+  }
+
+  private patchErrors() {
+    if (typeof window === 'undefined') return;
+    window.addEventListener('error', (e) => {
+      this.log(`error ${e.message}`);
+    });
+    window.addEventListener('unhandledrejection', (e) => {
+      this.log(`unhandledrejection ${(e as PromiseRejectionEvent).reason}`);
+    });
+  }
+
+  log(message: string) {
+    const entry: LogEntry = { timestamp: Date.now(), message };
+    this.logs.push(entry);
+    if (this.logs.length > 500) {
+      this.logs.shift();
+    }
+    this.emitter.dispatchEvent(new Event('log'));
+  }
+
+  clear() {
+    this.logs = [];
+    this.emitter.dispatchEvent(new Event('log'));
+  }
+
+  getLogs(): string[] {
+    return this.logs.map((l) => `[${format(l.timestamp, 'HH:mm:ss')}] ${l.message}`);
+  }
+
+  subscribe(callback: () => void) {
+    this.emitter.addEventListener('log', callback);
+    return () => this.emitter.removeEventListener('log', callback);
+  }
+}
+
+export default EventLogger;


### PR DESCRIPTION
## Summary
- add `EventLogger` service to capture API events and errors
- overlay logs with `LoggingOverlay` component
- mount logging overlay in `Layout`
- initialize logger in `main.tsx`

## Testing
- `npm run lint`
- `npm test` *(fails to exit watch mode; manually cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_6858fd38fcd48320a48239eafd696029