### PR TITLE
Add admin-only logs and detailed rain forecast

### DIFF
--- a/src/components/LoggingOverlay.tsx
+++ b/src/components/LoggingOverlay.tsx
@@ -6,10 +6,12 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { Badge } from '@/components/ui/badge';
 import EventLogger from '@/services/EventLogger';
 import { Copy, Trash2, FileText, Play, Pause } from 'lucide-react';
+import { useIsAdmin } from '@/hooks/useIsAdmin';
 
 const logger = EventLogger.getInstance();
 
 const LoggingOverlay: React.FC = () => {
+  const isAdmin = useIsAdmin();
   const [open, setOpen] = useState(false);
   const [logs, setLogs] = useState<string[]>(logger.getLogs());
   const [autoScroll, setAutoScroll] = useState(true);
@@ -27,6 +29,10 @@ const LoggingOverlay: React.FC = () => {
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
     }
   }, [logs, autoScroll]);
+
+  if (!isAdmin) {
+    return null;
+  }
 
   const copyLogs = async () => {
     try {

--- a/src/components/landing/WeatherForecastSection.tsx
+++ b/src/components/landing/WeatherForecastSection.tsx
@@ -7,7 +7,12 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { Link } from 'react-router-dom';
-import { fetchRainForecastWithCoords, fetchRainForecast } from '@/queries/content';
+import {
+  fetchRainForecastWithCoords,
+  fetchRainForecast,
+  fetchHourlyPrecipitation,
+} from '@/queries/content';
+import { format } from 'date-fns';
 import { WeatherContentService, WeatherCondition } from '@/services/WeatherContentService';
 import { WEATHER_LATITUDE, WEATHER_LONGITUDE, WEATHER_TIMEZONE } from '@/config/weather.config';
 import type { BlogPost } from '@/types/content';
@@ -32,6 +37,12 @@ const WeatherForecastSection: React.FC = () => {
       }
       return fetchRainForecast();
     },
+    enabled: true,
+  });
+
+  const { data: hourlyPrecipitation } = useQuery({
+    queryKey: ['weather-hourly', locationData?.lat, locationData?.lon],
+    queryFn: () => fetchHourlyPrecipitation(locationData?.lat || WEATHER_LATITUDE, locationData?.lon || WEATHER_LONGITUDE, WEATHER_TIMEZONE),
     enabled: true,
   });
 
@@ -127,6 +138,39 @@ const WeatherForecastSection: React.FC = () => {
     return 'bg-yellow-100 text-yellow-700';
   };
 
+  const getNextRainWindow = () => {
+    if (!hourlyPrecipitation) return null;
+    const { time, precipitation } = hourlyPrecipitation;
+    for (let i = 0; i < precipitation.length; i++) {
+      if (precipitation[i] > 0) {
+        const start = new Date(time[i]);
+        let j = i;
+        while (j < precipitation.length && precipitation[j] > 0) {
+          j++;
+        }
+        const end = new Date(time[j - 1]);
+        return { start, end };
+      }
+    }
+    return null;
+  };
+
+  const getRainAdvice = (window: { start: Date; end: Date } | null) => {
+    if (!window) return null;
+    const diffMs = window.start.getTime() - Date.now();
+    const diffMinutes = Math.round(diffMs / 60000);
+    if (diffMinutes <= 60 && diffMinutes >= 0) {
+      return 'Jetzt schnell noch die Gartenstühle reinholen!';
+    }
+    if (diffMinutes > 60 && diffMinutes <= 180) {
+      return `Regen in ca. ${Math.round(diffMinutes / 60)} Stunden.`;
+    }
+    return null;
+  };
+
+  const nextRainWindow = getNextRainWindow();
+  const rainAdvice = getRainAdvice(nextRainWindow);
+
   return (
     <section className="py-12 px-4 bg-gradient-to-br from-sky-50 to-blue-50">
       <div className="max-w-4xl mx-auto">
@@ -207,13 +251,21 @@ const WeatherForecastSection: React.FC = () => {
                         </Badge>
                       </div>
                     )}
+                    {hourlyPrecipitation && nextRainWindow && (
+                      <p className="text-sage-600 text-sm mt-1">
+                        Regen von {format(nextRainWindow.start, 'HH:mm')} bis {format(nextRainWindow.end, 'HH:mm')}
+                      </p>
+                    )}
                   </div>
-                  
+
                   <div className="bg-accent-50 rounded-lg p-4 border border-accent-100">
                     <p className="text-earth-700 font-medium mb-2">🌱 Mariannes Tipp für heute:</p>
                     <p className="text-sage-700 text-sm">
                       {getActivitySuggestion(precipitation)}
                     </p>
+                    {rainAdvice && (
+                      <p className="text-sage-700 text-sm mt-2 font-medium">{rainAdvice}</p>
+                    )}
                   </div>
                 </div>
               )}

--- a/src/hooks/useIsAdmin.ts
+++ b/src/hooks/useIsAdmin.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '@/integrations/supabase/client';
+
+export function useIsAdmin() {
+  const [isAdmin, setIsAdmin] = useState(false);
+
+  useEffect(() => {
+    const checkAdmin = async () => {
+      const { data: { session } } = await supabase.auth.getSession();
+      const user = session?.user;
+      if (!user) {
+        setIsAdmin(false);
+        return;
+      }
+      const { data, error } = await supabase
+        .from('user_roles')
+        .select('role')
+        .eq('user_id', user.id)
+        .eq('role', 'admin');
+      if (error) {
+        console.error('Error checking admin role:', error);
+        setIsAdmin(false);
+        return;
+      }
+      setIsAdmin((data?.length ?? 0) > 0);
+    };
+
+    checkAdmin();
+
+    const { data: listener } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (session?.user) {
+        checkAdmin();
+      } else {
+        setIsAdmin(false);
+      }
+    });
+
+    return () => {
+      listener?.subscription.unsubscribe();
+    };
+  }, []);
+
+  return isAdmin;
+}

--- a/src/queries/content.ts
+++ b/src/queries/content.ts
@@ -2,7 +2,7 @@
 import { supabase } from '@/integrations/supabase/client';
 import type { BlogPost } from '@/types/content';
 import { WEATHER_BASE_URL, WEATHER_LATITUDE, WEATHER_LONGITUDE, WEATHER_TIMEZONE } from '@/config/weather.config';
-import { isBlogPost, isWeatherResponse } from '@/utils/typeguards';
+import { isBlogPost, isWeatherResponse, isHourlyWeatherResponse } from '@/utils/typeguards';
 
 export interface CommentRow {
   id: string;
@@ -95,6 +95,35 @@ export const fetchRainForecastWithCoords = async (
       throw new Error('Invalid weather API response');
     }
     return data.daily.precipitation_sum[0] ?? null;
+  } catch (err) {
+    throw new Error(`Error fetching weather data: ${err instanceof Error ? err.message : String(err)}`);
+  }
+};
+
+export interface HourlyPrecipitation {
+  time: string[];
+  precipitation: number[];
+}
+
+export const fetchHourlyPrecipitation = async (
+  latitude: number | string = WEATHER_LATITUDE,
+  longitude: number | string = WEATHER_LONGITUDE,
+  timezone: string = WEATHER_TIMEZONE
+): Promise<HourlyPrecipitation | null> => {
+  const url = `${WEATHER_BASE_URL}?latitude=${encodeURIComponent(String(latitude))}&longitude=${encodeURIComponent(String(longitude))}&hourly=precipitation&forecast_days=1&timezone=${encodeURIComponent(timezone)}`;
+  try {
+    const res = await fetch(url);
+    if (!res.ok) {
+      throw new Error(`Weather request failed with status ${res.status}`);
+    }
+    const data = await res.json();
+    if (!isHourlyWeatherResponse(data)) {
+      throw new Error('Invalid weather API response');
+    }
+    return {
+      time: data.hourly.time,
+      precipitation: data.hourly.precipitation,
+    };
   } catch (err) {
     throw new Error(`Error fetching weather data: ${err instanceof Error ? err.message : String(err)}`);
   }

--- a/src/utils/typeguards.ts
+++ b/src/utils/typeguards.ts
@@ -31,3 +31,15 @@ export const isWeatherResponse = (
     data.daily.precipitation_sum.every((n: any) => typeof n === 'number')
   );
 };
+
+export const isHourlyWeatherResponse = (
+  data: any
+): data is { hourly: { time: string[]; precipitation: number[] } } => {
+  return (
+    data &&
+    typeof data === 'object' &&
+    data.hourly &&
+    Array.isArray(data.hourly.time) &&
+    Array.isArray(data.hourly.precipitation)
+  );
+};


### PR DESCRIPTION
## Summary
- restrict logging overlay to admin users via new `useIsAdmin` hook
- fetch hourly precipitation data from Open-Meteo
- show next rain window and advice in weather section

## Testing
- `npm run lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6859c11d6e6c83208e9c9348e4568c24