### PR TITLE
Add admin-only logs and detailed rain forecast

### DIFF
--- a/src/components/LoggingOverlay.tsx
+++ b/src/components/LoggingOverlay.tsx
@@ -6,10 +6,12 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { Badge } from '@/components/ui/badge';
 import EventLogger from '@/services/EventLogger';
 import { Copy, Trash2, FileText, Play, Pause } from 'lucide-react';
+import { useIsAdmin } from '@/hooks/useIsAdmin';
 
 const logger = EventLogger.getInstance();
 
 const LoggingOverlay: React.FC = () => {
+  const isAdmin = useIsAdmin();
   const [open, setOpen] = useState(false);
   const [logs, setLogs] = useState<string[]>(logger.getLogs());
   const [autoScroll, setAutoScroll] = useState(true);
@@ -27,6 +29,10 @@ const LoggingOverlay: React.FC = () => {
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
     }
   }, [logs, autoScroll]);
+
+  if (!isAdmin) {
+    return null;
+  }
 
   const copyLogs = async () => {
     try {

--- a/src/hooks/useIsAdmin.ts
+++ b/src/hooks/useIsAdmin.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '@/integrations/supabase/client';
+
+export function useIsAdmin() {
+  const [isAdmin, setIsAdmin] = useState(false);
+
+  useEffect(() => {
+    const checkAdmin = async () => {
+      const { data: { session } } = await supabase.auth.getSession();
+      const user = session?.user;
+      if (!user) {
+        setIsAdmin(false);
+        return;
+      }
+      const { data, error } = await supabase
+        .from('user_roles')
+        .select('role')
+        .eq('user_id', user.id)
+        .eq('role', 'admin');
+      if (error) {
+        console.error('Error checking admin role:', error);
+        setIsAdmin(false);
+        return;
+      }
+      setIsAdmin((data?.length ?? 0) > 0);
+    };
+
+    checkAdmin();
+
+    const { data: listener } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (session?.user) {
+        checkAdmin();
+      } else {
+        setIsAdmin(false);
+      }
+    });
+
+    return () => {
+      listener?.subscription.unsubscribe();
+    };
+  }, []);
+
+  return isAdmin;
+}

--- a/src/utils/typeguards.ts
+++ b/src/utils/typeguards.ts
@@ -31,3 +31,15 @@ export const isWeatherResponse = (
     data.daily.precipitation_sum.every((n: any) => typeof n === 'number')
   );
 };
+
+export const isHourlyWeatherResponse = (
+  data: any
+): data is { hourly: { time: string[]; precipitation: number[] } } => {
+  return (
+    data &&
+    typeof data === 'object' &&
+    data.hourly &&
+    Array.isArray(data.hourly.time) &&
+    Array.isArray(data.hourly.precipitation)
+  );
+};


### PR DESCRIPTION
## Summary
- restrict logging overlay to admin users via new `useIsAdmin` hook
- fetch hourly precipitation data from Open-Meteo
- show next rain window and advice in weather section
- **consolidate weather API calls** and make rain advice thresholds configurable

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: requires interactive package installation)*

------
https://chatgpt.com/codex/tasks/task_e_6859c11d6e6c83208e9c9348e4568c24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added rain timing insights and advice to the weather forecast section, including detection of upcoming rain windows and tailored messages based on rain timing.
	- Introduced admin-only access to the logging overlay, restricting its visibility to admin users.
- **Improvements**
	- Streamlined weather data fetching for both daily and hourly precipitation, improving accuracy and reliability of rain-related information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->