### PR TITLE
Fix weather forecast and admin utilities

### DIFF
--- a/src/components/LoggingOverlay.tsx
+++ b/src/components/LoggingOverlay.tsx
@@ -11,7 +11,7 @@ import { useIsAdmin } from '@/hooks/useIsAdmin';
 const logger = EventLogger.getInstance();
 
 const LoggingOverlay: React.FC = () => {
-  const isAdmin = useIsAdmin();
+  const { isAdmin, isLoading } = useIsAdmin();
   const [open, setOpen] = useState(false);
   const [logs, setLogs] = useState<string[]>(logger.getLogs());
   const [autoScroll, setAutoScroll] = useState(true);
@@ -29,6 +29,17 @@ const LoggingOverlay: React.FC = () => {
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
     }
   }, [logs, autoScroll]);
+
+  if (isLoading) {
+    return (
+      <div className="fixed bottom-4 right-4 z-50">
+        <Button variant="secondary" size="sm" disabled className="shadow-lg">
+          <FileText className="w-4 h-4 mr-2 animate-spin" />
+          Loading...
+        </Button>
+      </div>
+    );
+  }
 
   if (!isAdmin) {
     return null;

--- a/src/queries/content.ts
+++ b/src/queries/content.ts
@@ -139,13 +139,15 @@ export const fetchCombinedWeatherData = async (
   longitude: number | string = WEATHER_LONGITUDE,
   timezone: string = WEATHER_TIMEZONE
 ): Promise<CombinedWeatherData> => {
-  const url = `${WEATHER_BASE_URL}?latitude=${encodeURIComponent(
-    String(latitude)
-  )}&longitude=${encodeURIComponent(
-    String(longitude)
-  )}&daily=precipitation_sum&hourly=precipitation&forecast_days=1&timezone=${encodeURIComponent(
+  const params = new URLSearchParams({
+    latitude: String(latitude),
+    longitude: String(longitude),
+    daily: 'precipitation_sum',
+    hourly: 'precipitation',
+    forecast_days: '1',
     timezone
-  )}`;
+  });
+  const url = `${WEATHER_BASE_URL}?${params.toString()}`;
   try {
     const res = await fetch(url);
     if (!res.ok) {
@@ -166,5 +168,38 @@ export const fetchCombinedWeatherData = async (
     throw new Error(
       `Error fetching weather data: ${err instanceof Error ? err.message : String(err)}`
     );
+  }
+};
+
+export const fetchCityName = async (
+  latitude: number,
+  longitude: number
+): Promise<string | null> => {
+  const params = new URLSearchParams({
+    latitude: String(latitude),
+    longitude: String(longitude),
+    count: '1',
+    language: 'de'
+  });
+  const url = `https://geocoding-api.open-meteo.com/v1/reverse?${params.toString()}`;
+  try {
+    const res = await fetch(url);
+    if (!res.ok) {
+      throw new Error(`Geocoding request failed with status ${res.status}`);
+    }
+    const data = await res.json();
+    if (
+      data &&
+      Array.isArray(data.results) &&
+      data.results.length > 0 &&
+      typeof data.results[0].name === 'string' &&
+      data.results[0].name.trim().length > 0
+    ) {
+      return data.results[0].name as string;
+    }
+    return null;
+  } catch (err) {
+    console.error('Error fetching city name:', err);
+    return null;
   }
 };

--- a/src/utils/typeguards.ts
+++ b/src/utils/typeguards.ts
@@ -40,6 +40,8 @@ export const isHourlyWeatherResponse = (
     typeof data === 'object' &&
     data.hourly &&
     Array.isArray(data.hourly.time) &&
-    Array.isArray(data.hourly.precipitation)
+    Array.isArray(data.hourly.precipitation) &&
+    data.hourly.time.every((t: any) => typeof t === 'string') &&
+    data.hourly.precipitation.every((p: any) => typeof p === 'number')
   );
 };


### PR DESCRIPTION
## Summary
- show the detected city name when location access is granted
- add admin check loading state and optimize auth listener
- expose `fetchCityName` and improve weather URL construction
- validate hourly weather type guard fully
- refine rain window detection and advice logic
- display loading state in LoggingOverlay
- fix nitpicks for URLSearchParams and loading overlay styling

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: need to install vitest)*

------
https://chatgpt.com/codex/tasks/task_e_685a3d56fab08320ac213009a797d0ef

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Display of the user's city name in the weather forecast section, based on geolocation.
  - Loading indicator added for admin-only logging overlay while checking admin status.

- **Improvements**
  - Rain advice now provides more precise timing and skips rain windows that have already started.
  - City name retrieval falls back to a default label if fetching fails.
  - Enhanced validation for weather data to ensure more accurate results.

- **Bug Fixes**
  - Prevents redundant admin status checks for the same user, improving performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->