### PR TITLE
Update blog articles layout

### DIFF
--- a/src/components/blog/RelatedArticlesSection.tsx
+++ b/src/components/blog/RelatedArticlesSection.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+import { useQuery } from "@tanstack/react-query";
+import { supabase } from "@/integrations/supabase/client";
+import BlogPostCard from "./BlogPostCard";
+import type { BlogPost } from "@/types/content";
+
+interface RelatedArticlesSectionProps {
+  currentSlug: string;
+  category: string;
+  tags: string[];
+}
+
+const RelatedArticlesSection: React.FC<RelatedArticlesSectionProps> = ({ currentSlug, category, tags }) => {
+  const { data: posts, isLoading } = useQuery({
+    queryKey: ["related_articles", category, tags, currentSlug],
+    queryFn: async () => {
+      const query = supabase
+        .from("blog_posts")
+        .select("*")
+        .neq("slug", currentSlug)
+        .or([
+          `category.eq.${category}`,
+          ...(tags.length > 0 ? tags.map(tag => `tags.cs.{${tag}}`) : [])
+        ].join(","))
+        .limit(3);
+      const { data, error } = await query;
+      if (error) throw error;
+      const filtered = (data || []).filter((row: any) => !!row.published);
+      const unique = filtered.filter(
+        (post: any, idx: number, arr: any[]) =>
+          arr.findIndex((x) => x.slug === post.slug) === idx
+      );
+      return unique.map((row) => ({
+        id: row.id,
+        slug: row.slug,
+        title: row.title,
+        excerpt: row.excerpt,
+        content: row.content,
+        author: row.author,
+        publishedAt: row.published_at,
+        updatedAt: row.updated_at || undefined,
+        featuredImage: row.featured_image || "/placeholder.svg",
+        category: row.category || "",
+        tags: row.tags || [],
+        readingTime: row.reading_time || 5,
+        seo: {
+          title: row.seo_title || row.title,
+          description: row.seo_description || "",
+          keywords: row.seo_keywords || [],
+        },
+        featured: !!row.featured,
+        published: !!row.published,
+        structuredData: row.structured_data || undefined,
+        originalTitle: row.original_title || undefined,
+        ogImage: row.og_image || undefined,
+      })) as BlogPost[];
+    },
+  });
+
+  if (isLoading || posts === undefined || posts.length === 0) return null;
+
+  return (
+    <section className="mt-16">
+      <h2 className="text-2xl font-serif font-bold mb-6 text-sage-900">Verwandte Artikel</h2>
+      <div className="grid md:grid-cols-3 gap-8">
+        {posts.map((post) => (
+          <BlogPostCard key={post.slug} post={post} />
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default RelatedArticlesSection;

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -4,9 +4,8 @@ import { ArrowLeft } from 'lucide-react';
 import BlogPostHeader from "@/components/blog/BlogPostHeader";
 import BlogPostImage from "@/components/blog/BlogPostImage";
 import BlogPostContent from "@/components/blog/BlogPostContent";
-import BlogPostToRecipeSection from "@/components/blog/BlogPostToRecipeSection";
 import BlogPostShareSection from "@/components/blog/BlogPostShareSection";
-import RelatedBlogPostsCarousel from "@/components/blog/RelatedBlogPostsCarousel";
+import RelatedArticlesSection from "@/components/blog/RelatedArticlesSection";
 import { useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import type { BlogPost } from '@/types/content';
@@ -161,14 +160,7 @@ const BlogPostPage = () => {
           tags={post.tags}
         />
         <BlogPostContent content={post.content} />
-        <BlogPostToRecipeSection post={{
-          title: post.title,
-          content: post.content,
-          featuredImage: post.featuredImage,
-          slug: post.slug,
-          category: post.category
-        }} />
-        <BlogPostShareSection 
+        <BlogPostShareSection
           title={post.title}
           imageUrl={post.featuredImage}
           excerpt={post.excerpt}
@@ -177,8 +169,8 @@ const BlogPostPage = () => {
         {/* Call to Action Section */}
         <CallToActionSection category={post.category} />
         
-        {/* Related Articles Carousel */}
-        <RelatedBlogPostsCarousel
+        {/* Verwandte Artikel */}
+        <RelatedArticlesSection
           currentSlug={post.slug}
           category={post.category}
           tags={post.tags}


### PR DESCRIPTION
## Summary
- remove recipe creation section from blog posts
- show up to three related articles at the bottom of each post

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: @eslint/js missing)*

------
https://chatgpt.com/codex/tasks/task_e_685a62e802d483208352b570414dfff5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new section displaying related blog articles based on the current article's category and tags.

- **Refactor**
  - Replaced the previous related articles carousel with the new related articles section.
  - Removed the recipe-related section from blog post pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->