### PR TITLE
Enhance 404 page with helpful links

### DIFF
--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,5 +1,6 @@
-import { useLocation } from "react-router-dom";
+import { useLocation, Link } from "react-router-dom";
 import { useEffect } from "react";
+import { Flower } from "lucide-react";
 
 const NotFound = () => {
   const location = useLocation();
@@ -12,15 +13,35 @@ const NotFound = () => {
   }, [location.pathname]);
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100">
-      <div className="text-center">
-        <h1 className="text-4xl font-bold mb-4">404</h1>
-        <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
-        <a href="/" className="text-blue-500 hover:text-blue-700 underline">
-          Return to Home
-        </a>
-      </div>
-    </div>
+    <section className="min-h-[70vh] flex flex-col items-center justify-center text-center px-4 py-20 bg-gradient-to-br from-sage-50 via-cream to-accent-50">
+      <Flower className="h-12 w-12 text-sage-600 mb-6" />
+      <h1 className="text-5xl font-serif font-bold text-earth-800 mb-4">404 - Seite nicht gefunden</h1>
+      <p className="text-earth-600 mb-6">Hier wächst leider nichts. Vielleicht hast du dich im Garten verirrt?</p>
+      <p className="text-earth-600 mb-4 font-medium">Stöber doch in diesen Beeten:</p>
+      <ul className="space-y-2">
+        <li>
+          <Link to="/" className="text-primary hover:underline">
+            Startseite
+          </Link>
+        </li>
+        <li>
+          <Link to="/blog" className="text-primary hover:underline">
+            Blog
+          </Link>
+        </li>
+        <li>
+          <Link to="/aussaatkalender" className="text-primary hover:underline">
+            Aussaatkalender
+          </Link>
+        </li>
+        <li>
+          <Link to="/kontakt" className="text-primary hover:underline">
+            Kontakt
+          </Link>
+        </li>
+      </ul>
+      <p className="mt-8 text-sm text-sage-500">Keine Sorge, wir jäten das Unkraut und pflanzen hier bald etwas Neues.</p>
+    </section>
   );
 };
 


### PR DESCRIPTION
## Summary
- add links and a garden gag to the 404 page

## Testing
- `npm run lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_685a977a509883208ed659a4bc8d872e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the 404 Not Found page with a visually appealing gradient background, decorative icon, and garden-themed messaging in German.
  - Added navigation links to multiple sections (Home, Blog, Sowing Calendar, Contact) for easier site exploration from the error page.

- **Style**
  - Improved layout and design for a more engaging user experience on the Not Found page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->