### PR TITLE
Improve podcast UX and error handling

### DIFF
--- a/src/components/blog/BlogPodcastSection.tsx
+++ b/src/components/blog/BlogPodcastSection.tsx
@@ -18,6 +18,7 @@ const BlogPodcastSection: React.FC<BlogPodcastSectionProps> = ({
   blogTitle
 }) => {
   const [isGenerating, setIsGenerating] = useState(false);
+  const [showTranscript, setShowTranscript] = useState(false);
   const { toast } = useToast();
 
   // Query für bestehenden Podcast
@@ -171,11 +172,29 @@ const BlogPodcastSection: React.FC<BlogPodcastSectionProps> = ({
       )}
 
       {podcast?.status === 'ready' && podcast.audio_url && (
-        <BlogPodcastPlayer
-          audioUrl={podcast.audio_url}
-          title={podcast.title}
-          duration={podcast.duration_seconds}
-        />
+        <>
+          <BlogPodcastPlayer
+            audioUrl={podcast.audio_url}
+            title={podcast.title}
+            duration={podcast.duration_seconds}
+          />
+          {podcast.script_content && (
+            <div className="mt-4">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setShowTranscript((prev) => !prev)}
+              >
+                {showTranscript ? 'Transkript verstecken' : 'Transkript anzeigen'}
+              </Button>
+              {showTranscript && (
+                <div className="mt-2 whitespace-pre-wrap rounded-md bg-sage-50 p-4 text-sm text-earth-800">
+                  {podcast.script_content}
+                </div>
+              )}
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/supabase/functions/generate-podcast-audio/index.ts
+++ b/supabase/functions/generate-podcast-audio/index.ts
@@ -12,9 +12,9 @@ serve(async (req) => {
     return new Response('ok', { headers: corsHeaders })
   }
 
+  const { podcast_id } = await req.json().catch(() => ({ podcast_id: null }))
+
   try {
-    const { podcast_id } = await req.json()
-    
     if (!podcast_id) {
       throw new Error('Podcast ID ist erforderlich')
     }
@@ -96,19 +96,18 @@ serve(async (req) => {
 
   } catch (error) {
     console.error('Fehler bei Audio-Generierung:', error)
-    
+
     // Status auf error setzen
     try {
       const supabaseClient = createClient(
         Deno.env.get('SUPABASE_URL') ?? '',
         Deno.env.get('SUPABASE_ANON_KEY') ?? '',
       )
-      
-      const { podcast_id } = await req.json()
+
       if (podcast_id) {
         await supabaseClient
           .from('blog_podcasts')
-          .update({ 
+          .update({
             status: 'error',
             error_message: error.message
           })


### PR DESCRIPTION
## Summary
- fix Supabase function `generate-podcast-audio` to avoid reading request body twice
- add transcript toggle in `BlogPodcastSection`

## Testing
- `npm run lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_685b9d4b59788320b8a9ca5c7ab74985