### PR TITLE
Add script preview to podcast manager

### DIFF
--- a/src/components/admin/BlogPodcastManager.tsx
+++ b/src/components/admin/BlogPodcastManager.tsx
@@ -28,7 +28,8 @@ const BlogPodcastManager: React.FC = () => {
 
   const {
     generatingIds,
-    generatePodcastForPost,
+    generateScriptForPost,
+    generateAudioForPodcast,
     handlePlayPodcast,
     handleDownloadPodcast
   } = usePodcastActions(refetchPodcasts, refetchBlogPosts);
@@ -95,7 +96,8 @@ const BlogPodcastManager: React.FC = () => {
             blogPosts={filteredBlogPosts}
             podcasts={podcasts}
             generatingIds={generatingIds}
-            onGeneratePodcast={generatePodcastForPost}
+            onGenerateScript={generateScriptForPost}
+            onGenerateAudio={generateAudioForPodcast}
             onPlayPodcast={handlePlayPodcast}
             onDownloadPodcast={handleDownloadPodcast}
           />

--- a/src/components/admin/hooks/usePodcastActions.tsx
+++ b/src/components/admin/hooks/usePodcastActions.tsx
@@ -3,70 +3,106 @@ import { useState } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
 
-export const usePodcastActions = (refetchPodcasts: () => void, refetchBlogPosts: () => void) => {
+export const usePodcastActions = (
+  refetchPodcasts: () => void,
+  refetchBlogPosts: () => void
+) => {
   const [generatingIds, setGeneratingIds] = useState<Set<string>>(new Set());
   const { toast } = useToast();
 
-  const generatePodcastForPost = async (blogPostId: string, title: string) => {
+  const generateScriptForPost = async (blogPostId: string, title: string) => {
     setGeneratingIds(prev => new Set(prev).add(blogPostId));
-    
+
     try {
       toast({
-        title: "Podcast-Generierung gestartet",
-        description: `Erstelle liebevollen Podcast für "${title}" mit Mariannes warmer Stimme`,
+        title: 'Skript wird erstellt',
+        description: `Marianne schreibt ein liebevolles Skript für "${title}"`,
       });
 
-      // Script generieren
-      const { error: scriptError } = await supabase.functions.invoke(
-        'generate-podcast-script',
-        { body: { blog_post_id: blogPostId } }
-      );
+      const { error } = await supabase.functions.invoke('generate-podcast-script', {
+        body: { blog_post_id: blogPostId },
+      });
 
-      if (scriptError) {
-        throw new Error(`Script-Generierung fehlgeschlagen: ${scriptError.message}`);
-      }
-
-      // Kurz warten und Podcast-ID holen
-      await new Promise(resolve => setTimeout(resolve, 2000));
-      
-      const { data: podcast } = await supabase
-        .from('blog_podcasts')
-        .select('id')
-        .eq('blog_post_id', blogPostId)
-        .single();
-
-      if (podcast) {
-        // Audio generieren
-        const { error: audioError } = await supabase.functions.invoke(
-          'generate-podcast-audio',
-          { body: { podcast_id: podcast.id } }
-        );
-
-        if (audioError) {
-          throw new Error(`Audio-Generierung fehlgeschlagen: ${audioError.message}`);
-        }
+      if (error) {
+        throw new Error(`Script-Generierung fehlgeschlagen: ${error.message}`);
       }
 
       toast({
-        title: "Podcast erfolgreich erstellt",
-        description: `Mariannes liebevoller Podcast für "${title}" ist verfügbar`,
+        title: 'Skript erstellt',
+        description: 'Du kannst das Skript nun anschauen.',
       });
 
       refetchPodcasts();
       refetchBlogPosts();
-
-    } catch (error: any) {
+    } catch (err: any) {
       toast({
-        title: "Fehler bei Podcast-Erstellung",
-        description: error.message,
-        variant: "destructive",
+        title: 'Fehler bei Skript-Erstellung',
+        description: err.message,
+        variant: 'destructive',
       });
     } finally {
       setGeneratingIds(prev => {
-        const newSet = new Set(prev);
-        newSet.delete(blogPostId);
-        return newSet;
+        const set = new Set(prev);
+        set.delete(blogPostId);
+        return set;
       });
+    }
+  };
+
+  const generateAudioForPodcast = async (
+    podcastId: string,
+    blogPostId: string,
+    title: string
+  ) => {
+    setGeneratingIds(prev => new Set(prev).add(blogPostId));
+
+    try {
+      toast({
+        title: 'Audio-Erstellung gestartet',
+        description: `Annika vertont nun das Skript für "${title}"`,
+      });
+
+      const { error } = await supabase.functions.invoke('generate-podcast-audio', {
+        body: { podcast_id: podcastId },
+      });
+
+      if (error) {
+        throw new Error(`Audio-Generierung fehlgeschlagen: ${error.message}`);
+      }
+
+      toast({
+        title: 'Podcast fertig',
+        description: `Der Podcast zu "${title}" ist jetzt verfügbar`,
+      });
+
+      refetchPodcasts();
+      refetchBlogPosts();
+    } catch (err: any) {
+      toast({
+        title: 'Fehler bei Audio-Erstellung',
+        description: err.message,
+        variant: 'destructive',
+      });
+    } finally {
+      setGeneratingIds(prev => {
+        const set = new Set(prev);
+        set.delete(blogPostId);
+        return set;
+      });
+    }
+  };
+
+  const generatePodcastForPost = async (blogPostId: string, title: string) => {
+    await generateScriptForPost(blogPostId, title);
+
+    const { data: podcast } = await supabase
+      .from('blog_podcasts')
+      .select('id')
+      .eq('blog_post_id', blogPostId)
+      .single();
+
+    if (podcast) {
+      await generateAudioForPodcast(podcast.id, blogPostId, title);
     }
   };
 
@@ -83,6 +119,8 @@ export const usePodcastActions = (refetchPodcasts: () => void, refetchBlogPosts:
 
   return {
     generatingIds,
+    generateScriptForPost,
+    generateAudioForPodcast,
     generatePodcastForPost,
     handlePlayPodcast,
     handleDownloadPodcast

--- a/src/components/admin/views/BlogPodcastList.tsx
+++ b/src/components/admin/views/BlogPodcastList.tsx
@@ -1,5 +1,5 @@
 
-import React from 'react';
+import React, { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -21,6 +21,7 @@ interface Podcast {
   blog_post_id: string;
   title: string;
   status: string;
+  script_content?: string;
   audio_url?: string;
   duration_seconds?: number;
   created_at: string;
@@ -30,7 +31,8 @@ interface BlogPodcastListProps {
   blogPosts: BlogPost[];
   podcasts: Podcast[];
   generatingIds: Set<string>;
-  onGeneratePodcast: (blogPostId: string, title: string) => void;
+  onGenerateScript: (blogPostId: string, title: string) => void;
+  onGenerateAudio: (podcastId: string, blogPostId: string, title: string) => void;
   onPlayPodcast: (audioUrl: string) => void;
   onDownloadPodcast: (audioUrl: string, title: string) => void;
 }
@@ -39,10 +41,24 @@ const BlogPodcastList: React.FC<BlogPodcastListProps> = ({
   blogPosts,
   podcasts,
   generatingIds,
-  onGeneratePodcast,
+  onGenerateScript,
+  onGenerateAudio,
   onPlayPodcast,
   onDownloadPodcast
 }) => {
+  const [openScripts, setOpenScripts] = useState<Set<string>>(new Set());
+
+  const toggleScript = (podcastId: string) => {
+    setOpenScripts(prev => {
+      const newSet = new Set(prev);
+      if (newSet.has(podcastId)) {
+        newSet.delete(podcastId);
+      } else {
+        newSet.add(podcastId);
+      }
+      return newSet;
+    });
+  };
   const getPodcastForPost = (blogPostId: string) => {
     return podcasts.find(p => p.blog_post_id === blogPostId);
   };
@@ -119,7 +135,17 @@ const BlogPodcastList: React.FC<BlogPodcastListProps> = ({
                         </div>
                       )}
 
-                      {podcast.audio_url && podcast.status === 'ready' && (
+                      {podcast.script_content && (
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => toggleScript(podcast.id)}
+                        >
+                          {openScripts.has(podcast.id) ? 'Skript verstecken' : 'Skript anschauen'}
+                        </Button>
+                      )}
+
+                      {podcast.audio_url && podcast.status === 'ready' ? (
                         <div className="flex items-center gap-1">
                           <Button
                             size="sm"
@@ -136,12 +162,31 @@ const BlogPodcastList: React.FC<BlogPodcastListProps> = ({
                             <Download className="h-4 w-4" />
                           </Button>
                         </div>
+                      ) : (
+                        <Button
+                          size="sm"
+                          onClick={() => onGenerateAudio(podcast.id, post.id, post.title)}
+                          disabled={isGenerating}
+                          className="bg-sage-600 hover:bg-sage-700"
+                        >
+                          {isGenerating ? (
+                            <>
+                              <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                              Wird erstellt...
+                            </>
+                          ) : (
+                            <>
+                              <Mic className="h-4 w-4 mr-2" />
+                              Audio erstellen
+                            </>
+                          )}
+                        </Button>
                       )}
                     </div>
                   ) : (
                     <Button
                       size="sm"
-                      onClick={() => onGeneratePodcast(post.id, post.title)}
+                      onClick={() => onGenerateScript(post.id, post.title)}
                       disabled={isGenerating}
                       className="bg-sage-600 hover:bg-sage-700"
                     >
@@ -160,6 +205,11 @@ const BlogPodcastList: React.FC<BlogPodcastListProps> = ({
                   )}
                 </div>
               </div>
+              {podcast && openScripts.has(podcast.id) && podcast.script_content && (
+                <div className="mt-4 whitespace-pre-wrap text-sm text-gray-700">
+                  {podcast.script_content}
+                </div>
+              )}
             </CardContent>
           </Card>
         );


### PR DESCRIPTION
## Summary
- allow creating podcast scripts separately from audio
- show script preview with toggle button
- enable generating audio after reviewing the script

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bb9ca8b0c8320a6d44acc7db0a246