### PR TITLE
Improve podcast manager error handling

### DIFF
--- a/src/components/admin/BlogPodcastManager.tsx
+++ b/src/components/admin/BlogPodcastManager.tsx
@@ -28,7 +28,8 @@ const BlogPodcastManager: React.FC = () => {
 
   const {
     generatingIds,
-    generatePodcastForPost,
+    generateScriptForPost,
+    generateAudioForPodcast,
     handlePlayPodcast,
     handleDownloadPodcast
   } = usePodcastActions(refetchPodcasts, refetchBlogPosts);
@@ -95,7 +96,8 @@ const BlogPodcastManager: React.FC = () => {
             blogPosts={filteredBlogPosts}
             podcasts={podcasts}
             generatingIds={generatingIds}
-            onGeneratePodcast={generatePodcastForPost}
+            onGenerateScript={generateScriptForPost}
+            onGenerateAudio={generateAudioForPodcast}
             onPlayPodcast={handlePlayPodcast}
             onDownloadPodcast={handleDownloadPodcast}
           />

--- a/src/components/admin/hooks/usePodcastActions.tsx
+++ b/src/components/admin/hooks/usePodcastActions.tsx
@@ -3,69 +3,117 @@ import { useState } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
 
-export const usePodcastActions = (refetchPodcasts: () => void, refetchBlogPosts: () => void) => {
+export const usePodcastActions = (
+  refetchPodcasts: () => void,
+  refetchBlogPosts: () => void
+) => {
   const [generatingIds, setGeneratingIds] = useState<Set<string>>(new Set());
   const { toast } = useToast();
 
-  const generatePodcastForPost = async (blogPostId: string, title: string) => {
+  const generateScriptForPost = async (blogPostId: string, title: string) => {
     setGeneratingIds(prev => new Set(prev).add(blogPostId));
-    
+
     try {
       toast({
-        title: "Podcast-Generierung gestartet",
-        description: `Erstelle liebevollen Podcast für "${title}" mit Mariannes warmer Stimme`,
+        title: 'Skript wird erstellt',
+        description: `Marianne schreibt ein liebevolles Skript für "${title}"`,
       });
 
-      // Script generieren
-      const { error: scriptError } = await supabase.functions.invoke(
-        'generate-podcast-script',
-        { body: { blog_post_id: blogPostId } }
-      );
+      const { error } = await supabase.functions.invoke('generate-podcast-script', {
+        body: { blog_post_id: blogPostId },
+      });
 
-      if (scriptError) {
-        throw new Error(`Script-Generierung fehlgeschlagen: ${scriptError.message}`);
+      if (error) {
+        throw new Error(`Script-Generierung fehlgeschlagen: ${error.message}`);
       }
 
-      // Kurz warten und Podcast-ID holen
-      await new Promise(resolve => setTimeout(resolve, 2000));
-      
-      const { data: podcast } = await supabase
+      toast({
+        title: 'Skript erstellt',
+        description: 'Du kannst das Skript nun anschauen.',
+      });
+
+      refetchPodcasts();
+      refetchBlogPosts();
+    } catch (err: any) {
+      toast({
+        title: 'Fehler bei Skript-Erstellung',
+        description: err.message,
+        variant: 'destructive',
+      });
+    } finally {
+      setGeneratingIds(prev => {
+        const set = new Set(prev);
+        set.delete(blogPostId);
+        return set;
+      });
+    }
+  };
+
+  const generateAudioForPodcast = async (
+    podcastId: string,
+    blogPostId: string,
+    title: string
+  ) => {
+    setGeneratingIds(prev => new Set(prev).add(blogPostId));
+
+    try {
+      toast({
+        title: 'Audio-Erstellung gestartet',
+        description: `Annika vertont nun das Skript für "${title}"`,
+      });
+
+      const { error } = await supabase.functions.invoke('generate-podcast-audio', {
+        body: { podcast_id: podcastId },
+      });
+
+      if (error) {
+        throw new Error(`Audio-Generierung fehlgeschlagen: ${error.message}`);
+      }
+
+      toast({
+        title: 'Podcast fertig',
+        description: `Der Podcast zu "${title}" ist jetzt verfügbar`,
+      });
+
+      refetchPodcasts();
+      refetchBlogPosts();
+    } catch (err: any) {
+      toast({
+        title: 'Fehler bei Audio-Erstellung',
+        description: err.message,
+        variant: 'destructive',
+      });
+    } finally {
+      setGeneratingIds(prev => {
+        const set = new Set(prev);
+        set.delete(blogPostId);
+        return set;
+      });
+    }
+  };
+
+  const generatePodcastForPost = async (blogPostId: string, title: string) => {
+    await generateScriptForPost(blogPostId, title);
+
+    try {
+      const { data: podcast, error } = await supabase
         .from('blog_podcasts')
         .select('id')
         .eq('blog_post_id', blogPostId)
         .single();
 
-      if (podcast) {
-        // Audio generieren
-        const { error: audioError } = await supabase.functions.invoke(
-          'generate-podcast-audio',
-          { body: { podcast_id: podcast.id } }
-        );
-
-        if (audioError) {
-          throw new Error(`Audio-Generierung fehlgeschlagen: ${audioError.message}`);
-        }
+      if (error) {
+        throw error;
       }
 
+      if (podcast) {
+        await generateAudioForPodcast(podcast.id, blogPostId, title);
+      }
+    } catch (err: any) {
       toast({
-        title: "Podcast erfolgreich erstellt",
-        description: `Mariannes liebevoller Podcast für "${title}" ist verfügbar`,
-      });
-
-      refetchPodcasts();
-      refetchBlogPosts();
-
-    } catch (error: any) {
-      toast({
-        title: "Fehler bei Podcast-Erstellung",
-        description: error.message,
-        variant: "destructive",
-      });
-    } finally {
-      setGeneratingIds(prev => {
-        const newSet = new Set(prev);
-        newSet.delete(blogPostId);
-        return newSet;
+        title: 'Fehler beim Podcast-Lookup',
+        description: err.message,
+        variant: 'destructive',
       });
     }
   };
@@ -83,6 +131,8 @@ export const usePodcastActions = (refetchPodcasts: () => void, refetchBlogPosts:
 
   return {
     generatingIds,
+    generateScriptForPost,
+    generateAudioForPodcast,
     generatePodcastForPost,
     handlePlayPodcast,
     handleDownloadPodcast


### PR DESCRIPTION
## Summary
- show disabled button while audio is generating
- update script creation button text
- handle errors when fetching the podcast after script creation

## Testing
- `npm run lint`
- `npm test` *(tests run in watch mode and were manually cancelled after completion)*

------
https://chatgpt.com/codex/tasks/task_e_685bb9ca8b0c8320a6d44acc7db0a246