### PR TITLE
Use ElevenLabs Audio Native

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "dompurify": "^3.2.6",
     "embla-carousel-react": "^8.3.0",
     "input-otp": "^1.2.4",
+    "lodash": "^4.17.21",
     "lucide-react": "^0.462.0",
     "next-themes": "^0.3.0",
     "react": "^18.3.1",

--- a/src/components/blog/ElevenLabsAudioNative.tsx
+++ b/src/components/blog/ElevenLabsAudioNative.tsx
@@ -1,8 +1,6 @@
-
-import React, { useEffect, useRef, useState } from 'react';
-import { Play, Pause, Volume2, Loader2 } from 'lucide-react';
-import { Button } from '@/components/ui/button';
+import React, { useEffect, useState } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
+import { Loader2 } from 'lucide-react';
 
 interface ElevenLabsAudioNativeProps {
   text: string;
@@ -14,111 +12,55 @@ interface ElevenLabsAudioNativeProps {
 const ElevenLabsAudioNative: React.FC<ElevenLabsAudioNativeProps> = ({
   text,
   title,
-  voiceId = '21m00Tcm4TlvDq8ikWAM', // Default German voice
-  className = ""
+  voiceId = '21m00Tcm4TlvDq8ikWAM',
+  className = "",
 }) => {
-  const [isPlaying, setIsPlaying] = useState(false);
+  const [htmlSnippet, setHtmlSnippet] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
-  const [audioUrl, setAudioUrl] = useState<string | null>(null);
-  const audioRef = useRef<HTMLAudioElement>(null);
-
-  const generateAudio = async () => {
-    if (audioUrl) return audioUrl;
-
-    setIsLoading(true);
-    try {
-      const response = await fetch('/api/elevenlabs-audio-native', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          text: text,
-          voice_id: voiceId,
-          model_id: 'eleven_multilingual_v2'
-        }),
-      });
-
-      if (!response.ok) {
-        throw new Error('Failed to generate audio');
-      }
-
-      const blob = await response.blob();
-      const url = URL.createObjectURL(blob);
-      setAudioUrl(url);
-      return url;
-    } catch (error) {
-      console.error('Error generating audio:', error);
-      return null;
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  const togglePlayPause = async () => {
-    const audio = audioRef.current;
-    if (!audio) return;
-
-    if (!audioUrl) {
-      const url = await generateAudio();
-      if (!url) return;
-      audio.src = url;
-    }
-
-    if (isPlaying) {
-      audio.pause();
-    } else {
-      await audio.play();
-    }
-    setIsPlaying(!isPlaying);
-  };
 
   useEffect(() => {
-    const audio = audioRef.current;
-    if (!audio) return;
+    const createProject = async () => {
+      setIsLoading(true);
+      try {
+        const response = await fetch('/api/elevenlabs-audio-native', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            text,
+            voice_id: voiceId,
+            model_id: 'eleven_multilingual_v2',
+            name: title,
+          }),
+        });
 
-    const handleEnded = () => setIsPlaying(false);
-    const handlePause = () => setIsPlaying(false);
-    const handlePlay = () => setIsPlaying(true);
+        if (!response.ok) {
+          throw new Error('Failed to create audio native project');
+        }
 
-    audio.addEventListener('ended', handleEnded);
-    audio.addEventListener('pause', handlePause);
-    audio.addEventListener('play', handlePlay);
-
-    return () => {
-      audio.removeEventListener('ended', handleEnded);
-      audio.removeEventListener('pause', handlePause);
-      audio.removeEventListener('play', handlePlay);
+        const data = await response.json();
+        setHtmlSnippet(data.html_snippet);
+      } catch (error) {
+        console.error('Error creating audio native project:', error);
+      } finally {
+        setIsLoading(false);
+      }
     };
-  }, []);
+
+    createProject();
+  }, [text, title, voiceId]);
 
   return (
     <Card className={`bg-gradient-to-r from-sage-50 to-accent-50 ${className}`}>
       <CardContent className="p-4">
-        <div className="flex items-center gap-3">
-          <div className="w-10 h-10 bg-sage-600 rounded-full flex items-center justify-center">
-            <Volume2 className="h-5 w-5 text-white" />
+        {isLoading && !htmlSnippet ? (
+          <div className="flex items-center gap-2 text-sm text-earth-700">
+            <Loader2 className="h-4 w-4 animate-spin" /> Projekt wird vorbereitet
           </div>
-          <div className="flex-1">
-            <h4 className="font-medium text-earth-800 text-sm">Audio von Marianne</h4>
-            <p className="text-xs text-earth-600">Höre dir den Artikel vor</p>
-          </div>
-          <Button
-            onClick={togglePlayPause}
-            disabled={isLoading}
-            size="sm"
-            className="bg-sage-600 hover:bg-sage-700"
-          >
-            {isLoading ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
-            ) : isPlaying ? (
-              <Pause className="h-4 w-4" />
-            ) : (
-              <Play className="h-4 w-4 ml-0.5" />
-            )}
-          </Button>
-        </div>
-        <audio ref={audioRef} preload="none" />
+        ) : (
+          <div dangerouslySetInnerHTML={{ __html: htmlSnippet ?? '' }} />
+        )}
       </CardContent>
     </Card>
   );

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -13,7 +13,6 @@ import RelatedArticlesSection from "@/components/blog/RelatedArticlesSection";
 import BlogComments from "@/components/blog/BlogComments";
 import { useToast } from "@/hooks/use-toast";
 import { generateUniqueSlug } from '@/utils/slugHelpers';
-import BlogPodcastSection from '@/components/blog/BlogPodcastSection';
 import ElevenLabsAudioNative from '@/components/blog/ElevenLabsAudioNative';
 import { Calendar, User, Tag } from 'lucide-react';
 
@@ -137,18 +136,12 @@ const BlogPost = () => {
         </div>
         
         <BlogPostContent content={post.content} />
-        
+
         <BlogPostShareSection
           title={post.title}
           excerpt={post.excerpt}
         />
-        
-        {/* Podcast Section */}
-        <BlogPodcastSection 
-          blogPostId={post.id}
-          blogTitle={post.title}
-        />
-        
+
         <CallToActionSection />
         
         <RelatedArticlesSection 


### PR DESCRIPTION
## Summary
- switch edge function to ElevenLabs Audio Native API
- render Audio Native player snippet
- remove old podcast section

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cce4997508320bfab0ac5e2947615

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified the audio playback component by removing all built-in audio controls and playback logic, now displaying only an HTML snippet provided by the backend.
  * Updated loading behavior to show a spinner while fetching the audio snippet.

* **Chores**
  * Removed the podcast section from blog posts for a cleaner interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->