### PR TITLE
Improve fallback for title optimization

### DIFF
--- a/supabase/functions/ai-content-insights/index.ts
+++ b/supabase/functions/ai-content-insights/index.ts
@@ -10,6 +10,43 @@ const corsHeaders = {
 
 const OPENAI_ADMIN_KEY = Deno.env.get("OPENAI_ADMIN_KEY");
 
+interface OptimizationResult {
+  optimizedTitle: string;
+  suggestedKeywords: string[];
+  contentImprovements: string[];
+  metaDescription: string;
+  structureRecommendations: string[];
+  readabilityScore: number;
+  seoScore: number;
+}
+
+interface CacheEntry {
+  value: OptimizationResult;
+  timestamp: number;
+}
+
+const heuristicCache = new Map<string, CacheEntry>();
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const CACHE_MAX_ENTRIES = 100;
+
+function getFromCache(key: string): OptimizationResult | undefined {
+  const entry = heuristicCache.get(key);
+  if (!entry) return undefined;
+  if (Date.now() - entry.timestamp > CACHE_TTL_MS) {
+    heuristicCache.delete(key);
+    return undefined;
+  }
+  return entry.value;
+}
+
+function setCache(key: string, value: OptimizationResult): void {
+  if (heuristicCache.size >= CACHE_MAX_ENTRIES) {
+    const oldestKey = heuristicCache.keys().next().value;
+    if (oldestKey) heuristicCache.delete(oldestKey);
+  }
+  heuristicCache.set(key, { value, timestamp: Date.now() });
+}
+
 serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
@@ -219,22 +256,103 @@ Gib eine JSON-Antwort mit:
 }
 
 async function optimizeContent(contentData: any, supabase: any) {
-  const response = await fetch("https://api.openai.com/v1/chat/completions", {
-    method: "POST",
-    headers: {
-      "Authorization": `Bearer ${OPENAI_ADMIN_KEY}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      model: "gpt-4o",
-      messages: [
-        {
-          role: "system",
-          content: "Du bist ein SEO- und Content-Optimierungs-Experte. Gib konkrete Optimierungsvorschläge für den gegebenen Content."
-        },
-        {
-          role: "user",
-          content: `Optimiere diesen Content:
+  if (!contentData) {
+    throw new Error('contentData is required');
+  }
+  if (!contentData.title && !contentData.content) {
+    throw new Error('Either title or content must be provided');
+  }
+
+  const buildHeuristic = (data: any): OptimizationResult => {
+    const cacheKey = `${data.title ?? ''}|${data.content ?? ''}`;
+    const cached = getFromCache(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
+    const clean = (data.content || '').replace(/<[^>]*>/g, '');
+    const words = clean.match(/[\p{L}\d]{4,}/giu) || [];
+
+    const freq: Record<string, number> = {};
+    for (const w of words) {
+      const lower = w.toLowerCase();
+      freq[lower] = (freq[lower] || 0) + 1;
+    }
+
+    const suggestedKeywords = Object.entries(freq)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5)
+      .map(([k]) => k);
+
+    const optimizedTitle = (data.title || '')
+      .trim()
+      .replace(/\s+/g, ' ')
+      .replace(/\s+([,.;!?])/g, '$1');
+
+    const truncated = clean.slice(0, 150);
+    const lastSpace = truncated.lastIndexOf(' ');
+    const metaDescription = (lastSpace > -1 ? truncated.slice(0, lastSpace) : truncated).trim();
+
+    const totalWordLength = words.reduce((sum, w) => sum + w.length, 0);
+    const avgWordLength = words.length ? totalWordLength / words.length : 0;
+    const sentences = clean.split(/[.!?]+/).filter((s) => s.trim().length > 0);
+    const avgSentenceLength = sentences.length ? words.length / sentences.length : words.length;
+    const complexWords = words.filter((w) => w.length > 6).length;
+    const complexRatio = words.length ? complexWords / words.length : 0;
+    const readabilityRaw = 100 - avgWordLength * 5 - avgSentenceLength - complexRatio * 20;
+    const readabilityScore = Math.round(Math.max(0, Math.min(100, readabilityRaw)));
+
+    const result = {
+      optimizedTitle,
+      suggestedKeywords,
+      contentImprovements: [
+        !/<h2|##/i.test(data.content || '') && 'Füge Zwischenüberschriften hinzu',
+        avgSentenceLength > 20 && 'Nutze kürzere Sätze',
+        !/<img/i.test(data.content || '') && 'Verwende aussagekräftige Bilder'
+      ].filter(Boolean),
+      metaDescription,
+      structureRecommendations: [
+        !/<h\d/i.test(data.content || '') && 'Verwende H2/H3 Überschriften',
+        !/(<ul|\n- )/i.test(data.content || '') && 'Setze Aufzählungen für wichtige Punkte ein'
+      ].filter(Boolean),
+      readabilityScore,
+      seoScore: 50 + Math.min(50, suggestedKeywords.length * 5)
+    };
+    setCache(cacheKey, result);
+    return result;
+  };
+
+  if (!OPENAI_ADMIN_KEY) {
+    console.warn('[AI Content Insights] OPENAI key missing, using heuristic');
+    const optimization = buildHeuristic(contentData);
+    return new Response(
+      JSON.stringify({
+        success: true,
+        optimization,
+        originalTitle: contentData.title,
+        optimizedAt: new Date().toISOString()
+      }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+
+  try {
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${OPENAI_ADMIN_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o',
+        messages: [
+          {
+            role: 'system',
+            content: 'Du bist ein SEO- und Content-Optimierungs-Experte. Gib konkrete Optimierungsvorschläge für den gegebenen Content.'
+          },
+          {
+            role: 'user',
+            content: `Optimiere diesen Content:
 
 Titel: ${contentData.title}
 Content: ${contentData.content?.substring(0, 1500)}...
@@ -249,25 +367,45 @@ Gib eine JSON-Antwort mit:
 - structureRecommendations (Array)
 - readabilityScore (0-100)
 - seoScore (0-100)`
-        }
-      ],
-      temperature: 0.3,
-      max_tokens: 2000,
-    }),
-  });
+          }
+        ],
+        temperature: 0.3,
+        max_tokens: 2000,
+      }),
+    });
 
-  const data = await response.json();
-  const optimization = JSON.parse(data.choices[0].message.content);
-
-  return new Response(
-    JSON.stringify({ 
-      success: true, 
-      optimization,
-      originalTitle: contentData.title,
-      optimizedAt: new Date().toISOString()
-    }),
-    {
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    const data = await response.json();
+    let optimization;
+    let usedOpenAI = true;
+    try {
+      optimization = JSON.parse(data.choices[0].message.content);
+    } catch (parseError) {
+      console.error('[AI Content Insights] Failed to parse OpenAI response:', parseError);
+      optimization = buildHeuristic(contentData);
+      usedOpenAI = false;
     }
-  );
+    console.log(`[AI Content Insights] Optimization generated via ${usedOpenAI ? 'OpenAI' : 'heuristic'} path`);
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        optimization,
+        originalTitle: contentData.title,
+        optimizedAt: new Date().toISOString()
+      }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  } catch (error) {
+    console.error('[AI Content Insights] Optimization via OpenAI failed:', error);
+    const optimization = buildHeuristic(contentData);
+    return new Response(
+      JSON.stringify({
+        success: true,
+        optimization,
+        originalTitle: contentData.title,
+        optimizedAt: new Date().toISOString()
+      }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- add type-safe cache with TTL and size limits
- refine heuristic builder to use typed cache helpers
- catch and log JSON parse errors from OpenAI API

## Testing
- `npm test` *(failed: vitest not found)*
- `npm run lint` *(failed: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685d1b9013548320bef8bbb129f17a59