### PR TITLE
Fix admin dashboard menus on mobile

### DIFF
--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -12,7 +12,7 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+      "flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground overflow-x-auto whitespace-nowrap",
       className
     )}
     {...props}

--- a/src/index.css
+++ b/src/index.css
@@ -105,6 +105,6 @@
   }
 
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground overflow-x-hidden;
   }
 }


### PR DESCRIPTION
## Summary
- prevent admin dashboard menu from sliding off-screen on mobile with horizontal scrolling
- hide horizontal overflow for the entire page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: prompts to install vitest)*

------
https://chatgpt.com/codex/tasks/task_e_685d4876904c83209f0e6170b7ed5156

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved tab navigation by enabling horizontal scrolling and preventing text wrapping in the tab list.
  * Enhanced page layout by restricting horizontal overflow, preventing unwanted horizontal scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->