### PR TITLE
Fix missing supabase import in GeminiService

### DIFF
--- a/src/services/GeminiService.ts
+++ b/src/services/GeminiService.ts
@@ -1,4 +1,6 @@
 
+import { supabase } from '@/integrations/supabase/client';
+
 export interface GeminiConfig {
   temperature?: number;
   maxOutputTokens?: number;


### PR DESCRIPTION
## Summary
- add the supabase client import to GeminiService

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d6caa90e483208456b599c025b7b9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal update to support integration with Supabase services. No visible changes to end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->