### PR TITLE
Add Gemini fallback for insights

### DIFF
--- a/supabase/functions/ai-content-insights/index.ts
+++ b/supabase/functions/ai-content-insights/index.ts
@@ -268,7 +268,12 @@ async function predictContentTrends(supabase: any) {
     throw new Error('Keine KI-Antwort erhalten');
   }
 
-  const trends = JSON.parse(trendsText);
+  let trends;
+  try {
+    trends = JSON.parse(trendsText);
+  } catch {
+    throw new Error('Invalid JSON response from AI');
+  }
 
   return new Response(
     JSON.stringify({

--- a/supabase/functions/ai-content-insights/index.ts
+++ b/supabase/functions/ai-content-insights/index.ts
@@ -203,7 +203,12 @@ async function generateContentInsights(supabase: any) {
     throw new Error('Keine KI-Antwort erhalten');
   }
 
-  const insights = JSON.parse(insightsText);
+  let insights;
+  try {
+    insights = JSON.parse(insightsText);
+  } catch {
+    throw new Error('Invalid JSON response from AI');
+  }
 
   return new Response(
     JSON.stringify({

--- a/supabase/functions/fetch-current-trends/index.ts
+++ b/supabase/functions/fetch-current-trends/index.ts
@@ -3,6 +3,7 @@ import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { corsHeaders } from "../_shared/cors.ts";
 
 const openAIApiKey = Deno.env.get("OPENAI_API_KEY");
+const geminiApiKey = Deno.env.get("GEMINI_API_KEY");
 
 serve(async (req) => {
   if (req.method === "OPTIONS") {
@@ -10,45 +11,63 @@ serve(async (req) => {
   }
 
   try {
-    if (!openAIApiKey) {
-      return new Response(
-        JSON.stringify({ error: "OPENAI_API_KEY not set" }),
-        { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
-      );
-    }
-
     const prompt = `Du bist ein deutschsprachiger Trend-Analyst.\nGib mir 5-10 aktuelle Keywords aus den Bereichen Garten und Küche als JSON-Array im Format [{"keyword":"...","relevance":0.9,"category":"garten"}].`;
 
-    const response = await fetch("https://api.openai.com/v1/chat/completions", {
-      method: "POST",
-      headers: {
-        "Authorization": `Bearer ${openAIApiKey}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        model: "gpt-4o",
-        messages: [
-          { role: "system", content: "Du lieferst nur JSON ohne Erklärungen." },
-          { role: "user", content: prompt }
-        ],
-        temperature: 0.7,
-        max_tokens: 300,
-      }),
-    });
+    let resultText: string | null = null;
 
-    if (!response.ok) {
-      const err = await response.text();
-      return new Response(JSON.stringify({ error: err }), {
-        status: response.status,
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-      });
+    if (openAIApiKey) {
+      try {
+        const response = await fetch("https://api.openai.com/v1/chat/completions", {
+          method: "POST",
+          headers: {
+            "Authorization": `Bearer ${openAIApiKey}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            model: "gpt-4o",
+            messages: [
+              { role: "system", content: "Du lieferst nur JSON ohne Erklärungen." },
+              { role: "user", content: prompt }
+            ],
+            temperature: 0.7,
+            max_tokens: 300,
+          }),
+        });
+        if (response.ok) {
+          const data = await response.json();
+          resultText = data.choices?.[0]?.message?.content ?? null;
+        }
+      } catch (err) {
+        console.error('[fetch-current-trends] OpenAI request failed:', err);
+      }
     }
 
-    const data = await response.json();
-    const content = data.choices?.[0]?.message?.content || "[]";
+    if (!resultText && geminiApiKey) {
+      try {
+        const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=${geminiApiKey}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            contents: [{ parts: [{ text: prompt }] }],
+            generationConfig: { temperature: 0.7, maxOutputTokens: 300 }
+          })
+        });
+        if (response.ok) {
+          const data = await response.json();
+          resultText = data.candidates?.[0]?.content?.parts?.[0]?.text ?? null;
+        }
+      } catch (err) {
+        console.error('[fetch-current-trends] Gemini request failed:', err);
+      }
+    }
+
+    if (!resultText) {
+      return new Response(JSON.stringify({ error: 'No AI response' }), { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+    }
+
     let trends;
     try {
-      trends = JSON.parse(content);
+      trends = JSON.parse(resultText);
     } catch (_) {
       trends = [];
     }


### PR DESCRIPTION
## Summary
- add Gemini function helper in `ai-content-insights`
- use Gemini when OpenAI fails for performance analysis and insights
- use Gemini for trend fetching when OpenAI is unavailable

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685db37026e08320b10f525548555b1a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Gemini as an alternative AI provider for content insights and trend generation, with automatic fallback if OpenAI is unavailable.

* **Bug Fixes**
  * Improved error handling and fallback mechanisms to ensure more reliable AI responses even if one provider fails.

* **Refactor**
  * Enhanced prompt construction and response parsing for clarity and robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->