### PR TITLE
Implement blog article sidebar navigation

### DIFF
--- a/src/components/blog/BlogPostContent.tsx
+++ b/src/components/blog/BlogPostContent.tsx
@@ -1,6 +1,14 @@
 import React from "react";
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import { slugify } from '@/utils/slugify';
+
+const extractText = (children: React.ReactNode): string => {
+  if (typeof children === 'string') return children;
+  if (Array.isArray(children)) return children.map(extractText).join('');
+  if (React.isValidElement(children)) return extractText(children.props.children);
+  return '';
+};
 
 type BlogPostContentProps = {
   content: string;
@@ -11,9 +19,24 @@ const BlogPostContent: React.FC<BlogPostContentProps> = ({ content }) => (
     <ReactMarkdown 
       remarkPlugins={[remarkGfm]}
       components={{
-        h1: ({node, ...props}) => <h1 className="text-3xl md:text-4xl font-serif font-bold text-earth-800 mb-6" {...props} />,
-        h2: ({node, ...props}) => <h2 className="text-2xl md:text-3xl font-serif font-bold text-earth-800 mt-8 mb-4" {...props} />,
-        h3: ({node, ...props}) => <h3 className="text-xl md:text-2xl font-serif font-bold text-earth-800 mt-6 mb-3" {...props} />,
+        h1: ({ node, ...props }) => {
+          const id = slugify(extractText(props.children));
+          return (
+            <h1 id={id} className="text-3xl md:text-4xl font-serif font-bold text-earth-800 mb-6" {...props} />
+          );
+        },
+        h2: ({ node, ...props }) => {
+          const id = slugify(extractText(props.children));
+          return (
+            <h2 id={id} className="text-2xl md:text-3xl font-serif font-bold text-earth-800 mt-8 mb-4" {...props} />
+          );
+        },
+        h3: ({ node, ...props }) => {
+          const id = slugify(extractText(props.children));
+          return (
+            <h3 id={id} className="text-xl md:text-2xl font-serif font-bold text-earth-800 mt-6 mb-3" {...props} />
+          );
+        },
         p: ({node, ...props}) => <p className="text-earth-600 mb-4 leading-relaxed" {...props} />,
         ul: ({node, ...props}) => <ul className="list-disc pl-6 mb-6 text-earth-600" {...props} />,
         ol: ({node, ...props}) => <ol className="list-decimal pl-6 mb-6 text-earth-600" {...props} />,

--- a/src/components/blog/BlogPostNavigationSidebar.tsx
+++ b/src/components/blog/BlogPostNavigationSidebar.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { useIsMobile } from '@/hooks/use-mobile';
+
+export type Heading = {
+  id: string;
+  text: string;
+  level: number;
+};
+
+interface BlogPostNavigationSidebarProps {
+  headings: Heading[];
+}
+
+const BlogPostNavigationSidebar: React.FC<BlogPostNavigationSidebarProps> = ({ headings }) => {
+  const isMobile = useIsMobile();
+
+  if (isMobile || headings.length === 0) return null;
+
+  return (
+    <aside className="hidden xl:block fixed top-32 right-8 w-64 text-sm">
+      <nav className="sticky top-32">
+        <h2 className="text-lg font-serif font-bold mb-4 text-earth-800">Inhalt</h2>
+        <ul className="space-y-2">
+          {headings.map(h => (
+            <li key={h.id} className={h.level === 3 ? 'ml-4' : ''}>
+              <a href={`#${h.id}`} className="text-sage-700 hover:text-sage-900">
+                {h.text}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </aside>
+  );
+};
+
+export default BlogPostNavigationSidebar;

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -1,5 +1,5 @@
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { Helmet } from "react-helmet";
 import { useQuery } from '@tanstack/react-query';
@@ -7,6 +7,7 @@ import { supabase } from "@/integrations/supabase/client";
 import type { Tables } from '@/integrations/supabase/types';
 import BlogStructuredData from "@/components/blog/BlogStructuredData";
 import BlogPostContent from "@/components/blog/BlogPostContent";
+import BlogPostNavigationSidebar, { Heading } from "@/components/blog/BlogPostNavigationSidebar";
 import BlogPostShareSection from "@/components/blog/BlogPostShareSection";
 import CallToActionSection from "@/components/blog/CallToActionSection";
 import RelatedArticlesSection from "@/components/blog/RelatedArticlesSection";
@@ -47,6 +48,20 @@ const BlogPost = () => {
       return data as Tables<'blog_posts'>;
     },
   });
+
+  const articleRef = useRef<HTMLElement | null>(null);
+  const [headings, setHeadings] = useState<Heading[]>([]);
+
+  useEffect(() => {
+    if (!articleRef.current) return;
+    const nodes = Array.from(articleRef.current.querySelectorAll('h2, h3'));
+    const newHeadings = nodes.map(el => ({
+      id: el.id,
+      text: el.textContent || '',
+      level: Number(el.tagName.replace('H', '')),
+    }));
+    setHeadings(newHeadings);
+  }, [post]);
 
   if (isLoading) {
     return <div className="text-center py-12">Lädt Artikel...</div>;
@@ -99,7 +114,8 @@ const BlogPost = () => {
         slug={post.slug}
       />
 
-      <article className="max-w-4xl mx-auto px-4 py-8">
+      <div className="relative">
+      <article ref={articleRef} className="max-w-4xl mx-auto px-4 py-8">
         {/* Blog Post Header */}
         <header className="mb-8">
           <div className="mb-4">
@@ -150,11 +166,13 @@ const BlogPost = () => {
           tags={post.tags}
         />
         
-        <BlogComments 
-          blogSlug={post.slug} 
+        <BlogComments
+          blogSlug={post.slug}
           userId={user?.id || null}
         />
       </article>
+      <BlogPostNavigationSidebar headings={headings} />
+      </div>
     </>
   );
 };


### PR DESCRIPTION
## Summary
- generate slug IDs for headings in `BlogPostContent`
- add `BlogPostNavigationSidebar` component
- extract headings from the article in `BlogPost` and render sidebar

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e47221abc8320b4674d3e1825811d