### PR TITLE
Implement garden bed management and Trefle import

### DIFF
--- a/src/components/GardenBedManager.tsx
+++ b/src/components/GardenBedManager.tsx
@@ -1,0 +1,98 @@
+import React, { useEffect, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import gardenBedService from '@/services/GardenBedService';
+import { supabase } from '@/integrations/supabase/client';
+import type { GardenBed } from '@/types/garden';
+
+const GardenBedManager: React.FC = () => {
+  const [beds, setBeds] = useState<GardenBed[]>([]);
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [userId, setUserId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const load = async () => {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) return;
+      setUserId(user.id);
+      try {
+        const userBeds = await gardenBedService.getBedsForUser(user.id);
+        setBeds(userBeds);
+      } catch (err) {
+        console.error('Error loading beds:', err);
+      }
+    };
+    load();
+  }, []);
+
+  const handleCreate = async () => {
+    if (!userId || !name.trim()) return;
+    setLoading(true);
+    try {
+      const bed = await gardenBedService.createBed(userId, name.trim(), description.trim());
+      setBeds([...beds, bed]);
+      setName('');
+      setDescription('');
+    } catch (err) {
+      console.error('Error creating bed:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!confirm('Beet wirklich löschen?')) return;
+    try {
+      await gardenBedService.deleteBed(id);
+      setBeds(beds.filter(b => b.id !== id));
+    } catch (err) {
+      console.error('Error deleting bed:', err);
+    }
+  };
+
+  if (!userId) {
+    return <p className="text-center">Bitte einloggen, um Beete zu verwalten.</p>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Neues Beet anlegen</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Input
+            value={name}
+            onChange={e => setName(e.target.value)}
+            placeholder="Name des Beets"
+          />
+          <Textarea
+            value={description}
+            onChange={e => setDescription(e.target.value)}
+            placeholder="Beschreibung (optional)"
+          />
+          <Button onClick={handleCreate} disabled={loading}>Beet erstellen</Button>
+        </CardContent>
+      </Card>
+
+      {beds.map(bed => (
+        <Card key={bed.id} className="border-sage-200">
+          <CardHeader className="flex flex-row items-center justify-between">
+            <CardTitle>{bed.name}</CardTitle>
+            <Button variant="outline" size="sm" onClick={() => handleDelete(bed.id)}>Löschen</Button>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-earth-700 mb-2">{bed.description}</p>
+            <p className="text-sm text-earth-500">{bed.plants.length} Pflanzen</p>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+};
+
+export default GardenBedManager;

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { supabase } from "@/integrations/supabase/client";
 import ProfileForm from "../components/ProfileForm";
+import GardenBedManager from "../components/GardenBedManager";
 import { Loader2 } from "lucide-react";
 
 const ProfilePage: React.FC = () => {
@@ -90,9 +91,12 @@ const ProfilePage: React.FC = () => {
   if (!profile) return <div className="mx-auto p-8 text-center">Kein Profil gefunden.</div>;
 
   return (
-    <div className="max-w-xl mx-auto py-10">
-      <h1 className="text-2xl font-bold mb-6">Dein Profil</h1>
-      <ProfileForm profile={profile} onUpdate={setProfile} />
+    <div className="max-w-xl mx-auto py-10 space-y-10">
+      <div>
+        <h1 className="text-2xl font-bold mb-6">Dein Profil</h1>
+        <ProfileForm profile={profile} onUpdate={setProfile} />
+      </div>
+      <GardenBedManager />
     </div>
   );
 };

--- a/src/services/GardenBedService.ts
+++ b/src/services/GardenBedService.ts
@@ -1,0 +1,117 @@
+import { supabase } from '@/integrations/supabase/client';
+import type { GardenBed } from '@/types/garden';
+
+class GardenBedService {
+  async getBedsForUser(userId: string): Promise<GardenBed[]> {
+    const { data, error } = await supabase
+      .from('garden_beds')
+      .select('*')
+      .eq('user_id', userId)
+      .order('created_at');
+    if (error) {
+      console.error('Error fetching beds:', error);
+      throw new Error(error.message);
+    }
+    return data as GardenBed[];
+  }
+
+  async createBed(userId: string, name: string, description = ''): Promise<GardenBed> {
+    const { data, error } = await supabase
+      .from('garden_beds')
+      .insert({ user_id: userId, name, description, plants: [] })
+      .select()
+      .single();
+    if (error) {
+      console.error('Error creating bed:', error);
+      throw new Error(error.message);
+    }
+    return data as GardenBed;
+  }
+
+  async updateBed(id: string, updates: Partial<GardenBed>): Promise<GardenBed> {
+    const { data, error } = await supabase
+      .from('garden_beds')
+      .update(updates)
+      .eq('id', id)
+      .select()
+      .single();
+    if (error) {
+      console.error('Error updating bed:', error);
+      throw new Error(error.message);
+    }
+    return data as GardenBed;
+  }
+
+  async deleteBed(id: string): Promise<void> {
+    const { error } = await supabase
+      .from('garden_beds')
+      .delete()
+      .eq('id', id);
+    if (error) {
+      console.error('Error deleting bed:', error);
+      throw new Error(error.message);
+    }
+  }
+
+  async addPlantToBed(bedId: string, plantId: string): Promise<GardenBed> {
+    const { data, error } = await supabase
+      .from('garden_beds')
+      .select('plants')
+      .eq('id', bedId)
+      .single();
+    if (error) {
+      console.error('Error loading bed:', error);
+      throw new Error(error.message);
+    }
+
+    const plants: string[] = data?.plants || [];
+    if (!plants.includes(plantId)) {
+      plants.push(plantId);
+    }
+
+    const { data: updated, error: updateError } = await supabase
+      .from('garden_beds')
+      .update({ plants })
+      .eq('id', bedId)
+      .select()
+      .single();
+
+    if (updateError) {
+      console.error('Error updating bed plants:', updateError);
+      throw new Error(updateError.message);
+    }
+    return updated as GardenBed;
+  }
+
+  async removePlantFromBed(bedId: string, plantId: string): Promise<GardenBed> {
+    const { data, error } = await supabase
+      .from('garden_beds')
+      .select('plants')
+      .eq('id', bedId)
+      .single();
+    if (error) {
+      console.error('Error loading bed:', error);
+      throw new Error(error.message);
+    }
+
+    const plants: string[] = data?.plants || [];
+    const filtered = plants.filter((p) => p !== plantId);
+
+    const { data: updated, error: updateError } = await supabase
+      .from('garden_beds')
+      .update({ plants: filtered })
+      .eq('id', bedId)
+      .select()
+      .single();
+
+    if (updateError) {
+      console.error('Error updating bed plants:', updateError);
+      throw new Error(updateError.message);
+    }
+    return updated as GardenBed;
+  }
+}
+
+export const gardenBedService = new GardenBedService();
+export default gardenBedService;
+

--- a/src/services/TrefleApiService.ts
+++ b/src/services/TrefleApiService.ts
@@ -1,5 +1,6 @@
 import { supabase } from '@/integrations/supabase/client';
 import type { TreflePlant, TreflePlantDetails, TrefleSearchResponse, TrefleFilterOptions } from '@/types/trefle';
+import sowingCalendarService from './SowingCalendarService';
 
 class TrefleApiService {
   private static instance: TrefleApiService;
@@ -78,6 +79,12 @@ class TrefleApiService {
       console.error('Error syncing plants to database:', error);
       throw new Error(`Failed to sync plants: ${error.message}`);
     }
+  }
+
+  async addPlantByIdToDatabase(plantId: number) {
+    const details = await this.getPlantDetails(plantId);
+    const mapped = this.mapToSowingCalendarFormat(details);
+    return sowingCalendarService.addPlant(mapped);
   }
 
   // Helper method to map Trefle data to our sowing calendar format

--- a/src/services/__tests__/TrefleApiService.test.ts
+++ b/src/services/__tests__/TrefleApiService.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { trefleApiService } from '../TrefleApiService';
+
+const mockPlant: any = {
+  id: 1,
+  scientific_name: 'Solanum lycopersicum',
+  common_name: 'Tomate',
+  family: 'Solanaceae',
+  image_url: 'img',
+  year: 1753,
+  family_common_name: 'Nachtschatten',
+  growth: {
+    days_to_harvest: null,
+    minimum_temperature: { deg_c: 10, deg_f: 50 },
+    maximum_temperature: { deg_c: 30, deg_f: 86 },
+    soil_humidity: 5,
+    soil_nutriments: null,
+    soil_salinity: null,
+    soil_texture: null,
+    soil_ph_minimum: null,
+    soil_ph_maximum: null,
+    light: 8,
+    atmospheric_humidity: null,
+    growth_months: [4,5,6,7,8],
+    bloom_months: [6,7,8],
+    fruit_months: [7,8,9],
+    row_spacing: { cm: 50, in: null },
+    spread: { cm: 40, in: null },
+    sowing_method: 'indirect'
+  },
+  specifications: {
+    ligneous_type: null,
+    growth_form: null,
+    growth_habit: null,
+    growth_rate: null,
+    edible: true,
+    vegetable: true,
+    edible_part: ['fruits'],
+    edible_use: 'fresh',
+    medicinal: null,
+    toxicity: null
+  },
+  distributions: { native: null, introduced: null }
+};
+
+describe('TrefleApiService mapToSowingCalendarFormat', () => {
+  it('converts plant details', () => {
+    const result = trefleApiService.mapToSowingCalendarFormat(mockPlant);
+    expect(result.name).toBe('Tomate');
+    expect(result.type).toBe('Gemüse');
+    expect(result.season).toContain('Frühling');
+    expect(result.season).toContain('Sommer');
+    expect(result.directSow.length).toBe(0);
+    expect(result.indoor[0]).toBe(1);
+    expect(result.plantOut[0]).toBe(3);
+    expect(result.harvest).toContain(9);
+  });
+});

--- a/src/types/garden.ts
+++ b/src/types/garden.ts
@@ -1,0 +1,9 @@
+export interface GardenBed {
+  id: string;
+  user_id: string;
+  name: string;
+  description?: string;
+  plants: string[];
+  created_at: string;
+  updated_at: string;
+}


### PR DESCRIPTION
## Summary
- introduce `GardenBedService` and `GardenBedManager` component to manage beds
- update profile page to use the new bed manager
- extend `TrefleApiService` with `addPlantByIdToDatabase`
- add typings for garden beds
- test Trefle mapping logic

## Testing
- `npm run lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6861b5557fb88320b8c8a983b838eb3f