### PR TITLE
Implement garden bed management and Trefle import

### DIFF
--- a/src/components/GardenBedManager.tsx
+++ b/src/components/GardenBedManager.tsx
@@ -39,8 +39,8 @@ const GardenBedManager: React.FC = () => {
   const handleCreate = async () => {
     if (!userId) return;
 
-    if (!name.trim() || !description.trim()) {
-      setCreateError('Name und Beschreibung sind erforderlich');
+    if (!name.trim()) {
+      setCreateError('Name ist erforderlich');
       return;
     }
 

--- a/src/components/GardenBedManager.tsx
+++ b/src/components/GardenBedManager.tsx
@@ -1,0 +1,149 @@
+import React, { useEffect, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { useToast } from '@/hooks/use-toast';
+import gardenBedService from '@/services/GardenBedService';
+import { supabase } from '@/integrations/supabase/client';
+import type { GardenBed } from '@/types/garden';
+
+const GardenBedManager: React.FC = () => {
+  const { toast } = useToast();
+
+  const [beds, setBeds] = useState<GardenBed[]>([]);
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [userId, setUserId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [deleteId, setDeleteId] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  useEffect(() => {
+    const load = async () => {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) return;
+      setUserId(user.id);
+      try {
+        const userBeds = await gardenBedService.getBedsForUser(user.id);
+        setBeds(userBeds);
+      } catch (err) {
+        console.error('Error loading beds:', err);
+      }
+    };
+    load();
+  }, []);
+
+  const handleCreate = async () => {
+    if (!userId) return;
+
+    if (!name.trim() || !description.trim()) {
+      setCreateError('Name und Beschreibung sind erforderlich');
+      return;
+    }
+
+    setCreateError(null);
+    setLoading(true);
+    try {
+      const bed = await gardenBedService.createBed(userId, name.trim(), description.trim());
+      setBeds([...beds, bed]);
+      setName('');
+      setDescription('');
+      toast({ title: 'Beet erstellt' });
+    } catch (err: any) {
+      console.error('Error creating bed:', err);
+      toast({ title: 'Fehler', description: err.message || 'Beet konnte nicht erstellt werden', variant: 'destructive' });
+      setCreateError('Beet konnte nicht erstellt werden');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDelete = (id: string) => {
+    setDeleteId(id);
+  };
+
+  const confirmDelete = async () => {
+    if (!deleteId) return;
+    setDeleting(true);
+    try {
+      await gardenBedService.deleteBed(deleteId);
+      setBeds(beds.filter(b => b.id !== deleteId));
+      toast({ title: 'Beet gelöscht' });
+    } catch (err: any) {
+      console.error('Error deleting bed:', err);
+      toast({ title: 'Fehler', description: err.message || 'Beet konnte nicht gelöscht werden', variant: 'destructive' });
+    } finally {
+      setDeleting(false);
+      setDeleteId(null);
+    }
+  };
+
+  if (!userId) {
+    return <p className="text-center">Bitte einloggen, um Beete zu verwalten.</p>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Neues Beet anlegen</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Input
+            value={name}
+            onChange={e => setName(e.target.value)}
+            placeholder="Name des Beets"
+          />
+          <Textarea
+            value={description}
+            onChange={e => setDescription(e.target.value)}
+            placeholder="Beschreibung (optional)"
+          />
+          {createError && <p className="text-sm text-destructive">{createError}</p>}
+          <Button onClick={handleCreate} disabled={loading}>{loading ? 'Speichern...' : 'Beet erstellen'}</Button>
+        </CardContent>
+      </Card>
+
+      {beds.map(bed => (
+        <Card key={bed.id} className="border-sage-200" role="article" aria-labelledby={`bed-title-${bed.id}`}> 
+          <CardHeader className="flex flex-row items-center justify-between">
+            <CardTitle id={`bed-title-${bed.id}`}>{bed.name}</CardTitle>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => handleDelete(bed.id)}
+              aria-label={`Beet ${bed.name} löschen`}
+              disabled={deleting && deleteId === bed.id}
+            >
+              {deleting && deleteId === bed.id ? 'Lösche...' : 'Löschen'}
+            </Button>
+          </CardHeader>
+          <CardContent>
+            {bed.description && <p className="text-sm text-earth-700 mb-2">{bed.description}</p>}
+            <p className="text-sm text-earth-500">{bed.plants.length} Pflanzen</p>
+          </CardContent>
+        </Card>
+      ))}
+
+      <Dialog open={!!deleteId} onOpenChange={(open) => !open && !deleting && setDeleteId(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Beet löschen?</DialogTitle>
+            <DialogDescription>Dieses Beet wird dauerhaft entfernt.</DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDeleteId(null)} disabled={deleting}>Abbrechen</Button>
+            <Button variant="destructive" onClick={confirmDelete} disabled={deleting}>
+              {deleting ? 'Lösche...' : 'Löschen'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+};
+
+export default GardenBedManager;

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -6,9 +6,17 @@ import ProfileForm from "../components/ProfileForm";
 import GardenBedManager from "../components/GardenBedManager";
 import { Loader2 } from "lucide-react";
 
+interface Profile {
+  id: string;
+  display_name: string;
+  avatar_url?: string | null;
+  is_premium?: boolean;
+  custom_role?: string | null;
+}
+
 const ProfilePage: React.FC = () => {
   const [loading, setLoading] = useState(true);
-  const [profile, setProfile] = useState<any>(null);
+  const [profile, setProfile] = useState<Profile | null>(null);
   const [session, setSession] = useState<any>(null);
   const [error, setError] = useState<string | null>(null);
   const navigate = useNavigate();
@@ -53,13 +61,13 @@ const ProfilePage: React.FC = () => {
           );
           setProfile(null);
         } else {
-          setProfile(inserted);
+          setProfile(inserted as Profile);
         }
         setLoading(false);
         return;
       }
 
-      setProfile(data);
+      setProfile(data as Profile);
       setLoading(false);
     };
     init();

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { supabase } from "@/integrations/supabase/client";
 import ProfileForm from "../components/ProfileForm";
+import GardenBedManager from "../components/GardenBedManager";
 import { Loader2 } from "lucide-react";
 
 const ProfilePage: React.FC = () => {
@@ -90,9 +91,12 @@ const ProfilePage: React.FC = () => {
   if (!profile) return <div className="mx-auto p-8 text-center">Kein Profil gefunden.</div>;
 
   return (
-    <div className="max-w-xl mx-auto py-10">
-      <h1 className="text-2xl font-bold mb-6">Dein Profil</h1>
-      <ProfileForm profile={profile} onUpdate={setProfile} />
+    <div className="max-w-xl mx-auto py-10 space-y-10">
+      <div>
+        <h1 className="text-2xl font-bold mb-6">Dein Profil</h1>
+        <ProfileForm profile={profile} onUpdate={setProfile} />
+      </div>
+      <GardenBedManager />
     </div>
   );
 };

--- a/src/services/GardenBedService.ts
+++ b/src/services/GardenBedService.ts
@@ -1,0 +1,135 @@
+import { supabase } from '@/integrations/supabase/client';
+import type { GardenBed } from '@/types/garden';
+
+class GardenBedService {
+  async getBedsForUser(userId: string): Promise<GardenBed[]> {
+    if (!userId?.trim()) {
+      throw new Error('User ID is required');
+    }
+
+    const { data, error } = await supabase
+      .from('garden_beds')
+      .select('*')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: true });
+    if (error) {
+      console.error('Error fetching beds:', error);
+      throw new Error(error.message);
+    }
+    return data as GardenBed[];
+  }
+
+  async createBed(userId: string, name: string, description = ''): Promise<GardenBed> {
+    if (!userId?.trim()) {
+      throw new Error('User ID is required');
+    }
+
+    if (!name?.trim()) {
+      throw new Error('Bed name is required');
+    }
+
+    const { data, error } = await supabase
+      .from('garden_beds')
+      .insert({ user_id: userId, name: name.trim(), description: description.trim(), plants: [] })
+      .select()
+      .single();
+    if (error) {
+      console.error('Error creating bed:', error);
+      throw new Error(error.message);
+    }
+    return data as GardenBed;
+  }
+
+  async updateBed(id: string, updates: Partial<GardenBed>): Promise<GardenBed> {
+    if (!id?.trim()) {
+      throw new Error('Bed ID is required');
+    }
+
+    const allowedFields = ['name', 'description', 'plants'] as const;
+    const filteredUpdates = Object.fromEntries(
+      Object.entries(updates).filter(([key]) =>
+        allowedFields.includes(key as typeof allowedFields[number])
+      )
+    );
+
+    if (Object.keys(filteredUpdates).length === 0) {
+      throw new Error('No valid fields to update');
+    }
+
+    const { data, error } = await supabase
+      .from('garden_beds')
+      .update(filteredUpdates)
+      .eq('id', id)
+      .select()
+      .single();
+    if (error) {
+      console.error('Error updating bed:', error);
+      throw new Error(error.message);
+    }
+    return data as GardenBed;
+  }
+
+  async deleteBed(id: string): Promise<void> {
+    const { error } = await supabase
+      .from('garden_beds')
+      .delete()
+      .eq('id', id);
+    if (error) {
+      console.error('Error deleting bed:', error);
+      throw new Error(error.message);
+    }
+  }
+
+  async addPlantToBed(bedId: string, plantId: string): Promise<GardenBed> {
+    if (!bedId?.trim() || !plantId?.trim()) {
+      throw new Error('Bed ID and Plant ID are required');
+    }
+
+    const { data: updated, error } = await supabase.rpc('add_plant_to_bed', {
+      bed_id: bedId,
+      plant_id: plantId
+    });
+
+    if (error) {
+      console.error('Error updating bed plants:', error);
+      throw new Error(error.message);
+    }
+    return updated as GardenBed;
+  }
+
+  async removePlantFromBed(bedId: string, plantId: string): Promise<GardenBed> {
+    if (!bedId?.trim() || !plantId?.trim()) {
+      throw new Error('Bed ID and Plant ID are required');
+    }
+
+    const { data, error } = await supabase
+      .from('garden_beds')
+      .select('plants')
+      .eq('id', bedId)
+      .single();
+    if (error) {
+      console.error('Error loading bed:', error);
+      throw new Error(error.message);
+    }
+
+    const plants: string[] = data?.plants || [];
+    const filtered = plants.filter((p) => p !== plantId);
+
+    const { data: updated, error: updateError } = await supabase
+      .from('garden_beds')
+      .update({ plants: filtered })
+      .eq('id', bedId)
+      .select()
+      .single();
+
+    if (updateError) {
+      console.error('Error updating bed plants:', updateError);
+      throw new Error(updateError.message);
+    }
+    return updated as GardenBed;
+  }
+}
+
+export const gardenBedService = new GardenBedService();
+export default gardenBedService;
+

--- a/src/services/TrefleApiService.ts
+++ b/src/services/TrefleApiService.ts
@@ -1,5 +1,6 @@
 import { supabase } from '@/integrations/supabase/client';
 import type { TreflePlant, TreflePlantDetails, TrefleSearchResponse, TrefleFilterOptions } from '@/types/trefle';
+import { sowingCalendarService } from './SowingCalendarService';
 
 class TrefleApiService {
   private static instance: TrefleApiService;
@@ -77,6 +78,17 @@ class TrefleApiService {
     } catch (error) {
       console.error('Error syncing plants to database:', error);
       throw new Error(`Failed to sync plants: ${error.message}`);
+    }
+  }
+
+  async addPlantByIdToDatabase(plantId: number): Promise<void> {
+    try {
+      const details = await this.getPlantDetails(plantId);
+      const mapped = this.mapToSowingCalendarFormat(details);
+      await sowingCalendarService.addPlant(mapped);
+    } catch (error) {
+      console.error('Error adding plant to database:', error);
+      throw error;
     }
   }
 

--- a/src/services/__tests__/TrefleApiService.test.ts
+++ b/src/services/__tests__/TrefleApiService.test.ts
@@ -60,7 +60,7 @@ describe('TrefleApiService mapToSowingCalendarFormat', () => {
     const plantWithMissingData = { ...mockPlant, growth: {} };
     const result = trefleApiService.mapToSowingCalendarFormat(plantWithMissingData);
     expect(result.season).toEqual([]);
-    expect(result.difficulty).toBe('Mittel');
+    expect(result.difficulty).toBe('Einfach');
   });
 
   it('classifies flower plants correctly', () => {

--- a/src/services/__tests__/TrefleApiService.test.ts
+++ b/src/services/__tests__/TrefleApiService.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { trefleApiService } from '../TrefleApiService';
+
+const mockPlant: any = {
+  id: 1,
+  scientific_name: 'Solanum lycopersicum',
+  common_name: 'Tomate',
+  family: 'Solanaceae',
+  image_url: 'img',
+  year: 1753,
+  family_common_name: 'Nachtschatten',
+  growth: {
+    days_to_harvest: null,
+    minimum_temperature: { deg_c: 10, deg_f: 50 },
+    maximum_temperature: { deg_c: 30, deg_f: 86 },
+    soil_humidity: 5,
+    soil_nutriments: null,
+    soil_salinity: null,
+    soil_texture: null,
+    soil_ph_minimum: null,
+    soil_ph_maximum: null,
+    light: 8,
+    atmospheric_humidity: null,
+    growth_months: [4,5,6,7,8],
+    bloom_months: [6,7,8],
+    fruit_months: [7,8,9],
+    row_spacing: { cm: 50, in: null },
+    spread: { cm: 40, in: null },
+    sowing_method: 'indirect'
+  },
+  specifications: {
+    ligneous_type: null,
+    growth_form: null,
+    growth_habit: null,
+    growth_rate: null,
+    edible: true,
+    vegetable: true,
+    edible_part: ['fruits'],
+    edible_use: 'fresh',
+    medicinal: null,
+    toxicity: null
+  },
+  distributions: { native: null, introduced: null }
+};
+
+describe('TrefleApiService mapToSowingCalendarFormat', () => {
+  it('converts plant details', () => {
+    const result = trefleApiService.mapToSowingCalendarFormat(mockPlant);
+    expect(result.name).toBe('Tomate');
+    expect(result.type).toBe('Gemüse');
+    expect(result.season).toContain('Frühling');
+    expect(result.season).toContain('Sommer');
+    expect(result.directSow.length).toBe(0);
+    expect(result.indoor[0]).toBe(1);
+    expect(result.plantOut[0]).toBe(3);
+    expect(result.harvest).toContain(9);
+  });
+
+  it('handles missing growth data gracefully', () => {
+    const plantWithMissingData = { ...mockPlant, growth: {} };
+    const result = trefleApiService.mapToSowingCalendarFormat(plantWithMissingData);
+    expect(result.season).toEqual([]);
+    expect(result.difficulty).toBe('Mittel');
+  });
+
+  it('classifies flower plants correctly', () => {
+    const flowerPlant = {
+      ...mockPlant,
+      specifications: {
+        ...mockPlant.specifications,
+        vegetable: false,
+        edible_part: ['flowers']
+      }
+    };
+    const result = trefleApiService.mapToSowingCalendarFormat(flowerPlant);
+    expect(result.type).toBe('Blumen');
+  });
+});

--- a/src/types/garden.ts
+++ b/src/types/garden.ts
@@ -1,0 +1,9 @@
+export interface GardenBed {
+  id: string;
+  user_id: string;
+  name: string;
+  description?: string;
+  plants: string[];
+  created_at: string;
+  updated_at: string;
+}


### PR DESCRIPTION
## Summary
- introduce `GardenBedService` and `GardenBedManager` component to manage beds
- update profile page to use the new bed manager
- extend `TrefleApiService` with `addPlantByIdToDatabase`
- add typings for garden beds
- test Trefle mapping logic
- fix UI/logic according to review feedback

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: Cannot find package 'vitest')*

------
https://chatgpt.com/codex/tasks/task_e_6861b5557fb88320b8c8a983b838eb3f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability for authenticated users to manage garden beds, including creating, viewing, and deleting beds from their profile page.
  * Each garden bed displays its name, description, and plant count, with accessible UI elements and confirmation dialogs for deletions.
  * Introduced functionality to add plants by ID to the database using detailed plant data.

* **Bug Fixes**
  * None.

* **Tests**
  * Added tests to verify correct mapping of plant data for sowing calendar features.

* **Documentation**
  * None.

* **Chores**
  * Introduced new interfaces and services to support garden bed and plant management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->