### PR TITLE
Add task timeline feature

### DIFF
--- a/src/components/admin/TaskTimeline.tsx
+++ b/src/components/admin/TaskTimeline.tsx
@@ -1,0 +1,107 @@
+import React, { useEffect, useState } from 'react';
+import { CalendarIcon, Plus } from 'lucide-react';
+import { DayPicker } from 'react-day-picker';
+import 'react-day-picker/dist/style.css';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { useToast } from '@/hooks/use-toast';
+import { cronJobService } from '@/services/CronJobService';
+import type { ScheduledTask } from '@/services/CronJobService';
+
+const TaskTimeline: React.FC = () => {
+  const [tasks, setTasks] = useState<ScheduledTask[]>([]);
+  const [selectedDate, setSelectedDate] = useState<Date | undefined>(undefined);
+  const [showDialog, setShowDialog] = useState(false);
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const { toast } = useToast();
+
+  useEffect(() => {
+    loadTasks();
+  }, []);
+
+  const loadTasks = async () => {
+    try {
+      const data = await cronJobService.getScheduledTasks();
+      setTasks(data);
+    } catch (err) {
+      console.error('[TaskTimeline] Error loading tasks', err);
+      toast({ title: 'Fehler', description: 'Aufgaben konnten nicht geladen werden', variant: 'destructive' });
+    }
+  };
+
+  const tasksForDay = (day: Date) => {
+    return tasks.filter(t => new Date(t.scheduled_for).toDateString() === day.toDateString());
+  };
+
+  const handleDayClick = (day: Date) => {
+    setSelectedDate(day);
+    setShowDialog(true);
+  };
+
+  const handleAddTask = async () => {
+    if (!selectedDate) return;
+    try {
+      await cronJobService.createScheduledTask({
+        name,
+        description,
+        function_name: 'generic-task',
+        scheduled_for: selectedDate.toISOString(),
+      });
+      toast({ title: 'Aufgabe erstellt', description: `Aufgabe für ${selectedDate.toLocaleDateString()} hinzugefügt.` });
+      setName('');
+      setDescription('');
+      setShowDialog(false);
+      loadTasks();
+    } catch (err) {
+      console.error('[TaskTimeline] Error creating task', err);
+      toast({ title: 'Fehler', description: 'Aufgabe konnte nicht erstellt werden', variant: 'destructive' });
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-2">
+        <CalendarIcon className="h-5 w-5" />
+        <h2 className="text-xl font-semibold">Aufgaben-Timeline</h2>
+      </div>
+      <DayPicker
+        mode="single"
+        selected={selectedDate}
+        onDayClick={handleDayClick}
+        modifiers={{
+          hasTasks: (day) => tasksForDay(day).length > 0,
+        }}
+        modifiersClassNames={{ hasTasks: 'bg-sage-100' }}
+      />
+      <Dialog open={showDialog} onOpenChange={setShowDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Neue Aufgabe am {selectedDate?.toLocaleDateString()}</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-3">
+            {tasksForDay(selectedDate || new Date()).length > 0 && (
+              <div className="space-y-1">
+                <p className="text-sm font-medium">Geplante Aufgaben:</p>
+                <ul className="list-disc list-inside text-sm">
+                  {tasksForDay(selectedDate || new Date()).map(t => (
+                    <li key={t.id}>{t.name}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            <Input placeholder="Aufgabenname" value={name} onChange={e => setName(e.target.value)} />
+            <Textarea placeholder="Beschreibung" value={description} onChange={e => setDescription(e.target.value)} />
+          </div>
+          <DialogFooter className="mt-4">
+            <Button onClick={handleAddTask} disabled={!name}>Speichern</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+};
+
+export default TaskTimeline;

--- a/src/components/admin/views/TimelineView.tsx
+++ b/src/components/admin/views/TimelineView.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import TaskTimeline from '../TaskTimeline';
+
+const TimelineView: React.FC = () => {
+  return (
+    <div>
+      <TaskTimeline />
+    </div>
+  );
+};
+
+export default TimelineView;

--- a/src/config/adminMenu.ts
+++ b/src/config/adminMenu.ts
@@ -96,6 +96,12 @@ export const adminMenuItems: AdminMenuItem[] = [
         icon: Volume2,
         path: '/admin/audio-generator'
       }
+      ,{
+        id: 'timeline',
+        title: 'Aufgaben-Timeline',
+        icon: Calendar,
+        path: '/admin/timeline'
+      }
     ]
   },
   {

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -10,6 +10,7 @@ import ContentStrategyView from '@/components/admin/views/ContentStrategyView';
 import ScheduledJobsView from '@/components/admin/views/ScheduledJobsView';
 import AudioSidebarView from '@/components/admin/views/AudioSidebarView';
 import SowingCalendarManager from '@/components/admin/SowingCalendarManager';
+import TimelineView from '@/components/admin/views/TimelineView';
 import AdminLayout from '@/components/admin/AdminLayout';
 
 const AdminDashboard = () => {
@@ -48,6 +49,8 @@ const AdminDashboard = () => {
         return <AudioSidebarView />;
       case 'sowing-calendar':
         return <SowingCalendarManager />;
+      case 'timeline':
+        return <TimelineView />;
       default:
         return <BlogPostsView />;
     }


### PR DESCRIPTION
## Summary
- add TaskTimeline component for creating tasks via calendar
- include new view in AdminDashboard
- register new "Aufgaben-Timeline" entry in admin menu

## Testing
- `npm run lint`
- `npm test` *(results: 3 test files passed)*

------
https://chatgpt.com/codex/tasks/task_e_68623caf1f00832098ddc15444da4bf8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a calendar-based timeline view for managing and viewing scheduled tasks in the admin dashboard.
  * Added the ability to create new tasks directly from the calendar interface.
  * Enhanced admin menu with a new "Aufgaben-Timeline" (Task Timeline) entry for easy navigation to the timeline view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->