### PR TITLE
Add 404 page for proper HTTP status

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>404 - Seite nicht gefunden | Mien Tuun</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ npm run dev
 
 ## Skripte
 - `npm run dev` – lokaler Entwicklungsserver
-- `npm run build` – Produktionsbuild in `dist` (erstellt automatisch eine `sitemap.xml`)
+- `npm run build` – Produktionsbuild in `dist` (erstellt automatisch eine `sitemap.xml` und eine `404.html`)
 - `npm run sitemap` – generiert `public/sitemap.xml`
 - `npm run lint` – Codequalität prüfen
 - `npm test` – Test-Suite ausführen


### PR DESCRIPTION
## Summary
- add a simple `404.html` so static hosting returns a real 404
- mention the 404 page in `README.md`

## Testing
- `npm ci`


------
https://chatgpt.com/codex/tasks/task_e_686251b1b9348320911dc18e0693faac

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated 404 error page for "Page not found" in German.

* **Documentation**
  * Updated instructions to reflect that the production build now generates both a sitemap and a 404 error page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->