### PR TITLE
Add layout validation utilities

### DIFF
--- a/src/utils/__tests__/layout.test.ts
+++ b/src/utils/__tests__/layout.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { detectOverlaps, resolveOverlaps, resizeItem, LayoutItem } from '../layout';
+
+describe('layout utilities', () => {
+  it('detects overlaps', () => {
+    const layout: LayoutItem[] = [
+      { i: 'a', x: 0, y: 0, w: 2, h: 2 },
+      { i: 'b', x: 1, y: 1, w: 2, h: 2 },
+      { i: 'c', x: 3, y: 0, w: 1, h: 1 }
+    ];
+    const overlaps = detectOverlaps(layout);
+    expect(overlaps).toEqual([{ item1: 'a', item2: 'b' }]);
+  });
+
+  it('resolves overlaps by moving items', () => {
+    const layout: LayoutItem[] = [
+      { i: 'a', x: 0, y: 0, w: 2, h: 2 },
+      { i: 'b', x: 1, y: 1, w: 2, h: 2 }
+    ];
+    const resolved = resolveOverlaps(layout);
+    expect(detectOverlaps(resolved)).toHaveLength(0);
+    const a = resolved.find(i => i.i === 'a')!;
+    const b = resolved.find(i => i.i === 'b')!;
+    expect(b.y).toBeGreaterThanOrEqual(a.y + a.h);
+  });
+
+  it('resizes item and keeps layout valid', () => {
+    const layout: LayoutItem[] = [
+      { i: 'a', x: 0, y: 0, w: 1, h: 1 },
+      { i: 'b', x: 0, y: 1, w: 1, h: 1 }
+    ];
+    const resized = resizeItem(layout, 'a', 1, 2);
+    expect(detectOverlaps(resized)).toHaveLength(0);
+    const b = resized.find(i => i.i === 'b')!;
+    expect(b.y).toBe(2);
+  });
+});

--- a/src/utils/layout.ts
+++ b/src/utils/layout.ts
@@ -1,0 +1,67 @@
+export interface LayoutItem {
+  i: string;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export interface Overlap {
+  item1: string;
+  item2: string;
+}
+
+export const detectOverlaps = (layout: LayoutItem[]): Overlap[] => {
+  const overlaps: Overlap[] = [];
+  for (let i = 0; i < layout.length; i++) {
+    for (let j = i + 1; j < layout.length; j++) {
+      const item1 = layout[i];
+      const item2 = layout[j];
+
+      const item1Right = item1.x + item1.w;
+      const item1Bottom = item1.y + item1.h;
+      const item2Right = item2.x + item2.w;
+      const item2Bottom = item2.y + item2.h;
+
+      if (!(item1Right <= item2.x || item2Right <= item1.x ||
+            item1Bottom <= item2.y || item2Bottom <= item1.y)) {
+        overlaps.push({ item1: item1.i, item2: item2.i });
+      }
+    }
+  }
+  return overlaps;
+};
+
+export const resolveOverlaps = (layout: LayoutItem[]): LayoutItem[] => {
+  const sorted = layout.map(item => ({ ...item })).sort((a, b) => a.y - b.y);
+  for (let i = 0; i < sorted.length; i++) {
+    const current = sorted[i];
+    for (let j = i + 1; j < sorted.length; j++) {
+      const other = sorted[j];
+      const currentRight = current.x + current.w;
+      const currentBottom = current.y + current.h;
+      const otherRight = other.x + other.w;
+      const otherBottom = other.y + other.h;
+      if (!(currentRight <= other.x || otherRight <= current.x ||
+            currentBottom <= other.y || otherBottom <= current.y)) {
+        other.y = currentBottom;
+      }
+    }
+  }
+  return sorted;
+};
+
+export const resizeItem = (
+  layout: LayoutItem[],
+  id: string,
+  newWidth: number,
+  newHeight: number,
+  resolve = true
+): LayoutItem[] => {
+  const updated = layout.map(item =>
+    item.i === id
+      ? { ...item, w: Math.max(1, newWidth), h: Math.max(1, newHeight) }
+      : { ...item }
+  );
+  return resolve ? resolveOverlaps(updated) : updated;
+};


### PR DESCRIPTION
## Summary
- add `layout.ts` utility module for detecting overlaps, resolving them, and resizing items
- add unit tests covering these utilities

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6864e49763b483208da4487d456a731a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced utilities for managing layouts, including detecting and resolving overlaps and resizing items within a layout.
* **Tests**
  * Added tests to verify overlap detection, resolution, and resizing functionality for layout items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->