### PR TITLE
Fix tests and add sitemap generator

### DIFF
--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -1,0 +1,44 @@
+import { createClient } from '@supabase/supabase-js';
+import { writeFile } from 'fs/promises';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const SUPABASE_URL = process.env.VITE_SUPABASE_URL || 'https://ublbxvpmoccmegtwaslh.supabase.co';
+const SUPABASE_KEY = process.env.VITE_SUPABASE_ANON_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InVibGJ4dnBtb2NjbWVndHdhc2xoIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDk5MjExNTksImV4cCI6MjA2NTQ5NzE1OX0.MHtBC8D73NtPBONH2Qg0-hBZsyUyfDTUYZgzB_HEHpQ';
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+
+async function generateSitemap() {
+  const { data: posts } = await supabase
+    .from('blog_posts')
+    .select('slug, updated_at, published_at')
+    .eq('status', 'veröffentlicht')
+    .eq('published', true);
+
+  const baseUrl = 'https://mien-tuun.de';
+  const currentDate = new Date().toISOString().split('T')[0];
+
+  let sitemap = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n` +
+    `  <url>\n    <loc>${baseUrl}</loc>\n    <lastmod>${currentDate}</lastmod>\n    <changefreq>daily</changefreq>\n    <priority>1.0</priority>\n  </url>\n  <url>\n    <loc>${baseUrl}/blog</loc>\n    <lastmod>${currentDate}</lastmod>\n    <changefreq>daily</changefreq>\n    <priority>0.9</priority>\n  </url>`;
+
+  posts?.forEach(post => {
+    const lastmod = (post.updated_at || post.published_at || currentDate).split('T')[0];
+    sitemap += `\n  <url>\n    <loc>${baseUrl}/blog/${post.slug}</loc>\n    <lastmod>${lastmod}</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.8</priority>\n  </url>`;
+  });
+
+  sitemap += '\n</urlset>';
+  return sitemap;
+}
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const outputPath = join(__dirname, '../public/sitemap.xml');
+
+generateSitemap()
+  .then(async xml => {
+    await writeFile(outputPath, xml);
+    console.log('Sitemap written to', outputPath);
+  })
+  .catch(err => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -3,8 +3,21 @@ import { writeFile } from 'fs/promises';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 
-const SUPABASE_URL = process.env.VITE_SUPABASE_URL || 'https://ublbxvpmoccmegtwaslh.supabase.co';
-const SUPABASE_KEY = process.env.VITE_SUPABASE_ANON_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InVibGJ4dnBtb2NjbWVndHdhc2xoIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDk5MjExNTksImV4cCI6MjA2NTQ5NzE1OX0.MHtBC8D73NtPBONH2Qg0-hBZsyUyfDTUYZgzB_HEHpQ';
+// scripts/generate-sitemap.mjs
+
+// … previous imports and code …
+
+const SUPABASE_URL = process.env.VITE_SUPABASE_URL;
+const SUPABASE_KEY = process.env.VITE_SUPABASE_ANON_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error(
+    'Missing required environment variables: VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY'
+  );
+  process.exit(1);
+}
+
+// … rest of the sitemap generation logic …
 
 const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
 

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -40,7 +40,14 @@ async function generateSitemap() {
 
   posts?.forEach(post => {
     const lastmod = (post.updated_at || post.published_at || currentDate).split('T')[0];
-    sitemap += `\n  <url>\n    <loc>${baseUrl}/blog/${post.slug}</loc>\n    <lastmod>${lastmod}</lastmod>\n    <changefreq>weekly</changefreq>\n    <priority>0.8</priority>\n  </url>`;
+    const encodedSlug = encodeURIComponent(post.slug);
+    sitemap += `
+  <url>
+    <loc>${baseUrl}/blog/${encodedSlug}</loc>
+    <lastmod>${lastmod}</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>`;
   });
 
   sitemap += '\n</urlset>';

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -22,11 +22,15 @@ if (!SUPABASE_URL || !SUPABASE_KEY) {
 const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
 
 async function generateSitemap() {
-  const { data: posts } = await supabase
+  const { data: posts, error } = await supabase
     .from('blog_posts')
     .select('slug, updated_at, published_at')
     .eq('status', 'veröffentlicht')
     .eq('published', true);
+
+  if (error) {
+    throw new Error(`Database query failed: ${error.message}`);
+  }
 
   const baseUrl = 'https://mien-tuun.de';
   const currentDate = new Date().toISOString().split('T')[0];

--- a/src/services/pipeline/__tests__/BlogPostPipelineService.test.ts
+++ b/src/services/pipeline/__tests__/BlogPostPipelineService.test.ts
@@ -20,7 +20,7 @@ const mockSuccessfulDb = () => {
   (supabase.from as any).mockImplementation(() => ({
     insert: () => ({
       select: () => ({
-        single: () => Promise.resolve({ data: { id: 1 }, error: null })
+        maybeSingle: () => Promise.resolve({ data: { id: 1 }, error: null })
       })
     }),
     update: () => ({
@@ -63,7 +63,7 @@ describe('BlogPostPipelineService', () => {
     (supabase.from as any).mockImplementation(() => ({
       insert: () => ({
         select: () => ({
-          single: () => Promise.resolve({ data: null, error: { message: 'db err' } })
+          maybeSingle: () => Promise.resolve({ data: null, error: { message: 'db err' } })
         })
       }),
       update: () => ({


### PR DESCRIPTION
## Summary
- fix unit tests by stubbing `maybeSingle`
- add missing `generate-sitemap.mjs` so `npm run build` works

## Testing
- `npx vitest run`
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687ce4941edc8320a4caa8092f704458

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a script to automatically generate an XML sitemap for the website, ensuring published blog posts are included for better search engine indexing.

* **Tests**
  * Updated test mocks to improve database query handling in blog post pipeline service tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->