### PR TITLE
Fix category consistency across frontend

### DIFF
--- a/src/components/admin/BlogMetaSection.tsx
+++ b/src/components/admin/BlogMetaSection.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import TagSelector from "./TagSelector";
+import { BLOG_CATEGORIES, SEASONS } from "@/config/blog.config";
 
 interface BlogMetaSectionProps {
   category: string;
@@ -20,24 +21,9 @@ interface BlogMetaSectionProps {
   loading: boolean;
 }
 
-const BLOG_CATEGORIES = [
-  { value: "Garten & Planung", label: "Garten & Planung" },
-  { value: "Pflanzenpflege", label: "Pflanzenpflege" },
-  { value: "Ernte & Küche", label: "Ernte & Küche" },
-  { value: "Nachhaltigkeit & Umwelt", label: "Nachhaltigkeit & Umwelt" },
-  { value: "Spezielle Gartenbereiche", label: "Spezielle Gartenbereiche" },
-  { value: "Selbermachen & Ausrüstung", label: "Selbermachen & Ausrüstung" },
-  { value: "Philosophie & Lifestyle", label: "Philosophie & Lifestyle" },
-  { value: "Allgemein", label: "Allgemein" },
-];
-
-const SEASONS = [
-  { value: "frühling", label: "Frühling" },
-  { value: "sommer", label: "Sommer" },
-  { value: "herbst", label: "Herbst" },
-  { value: "winter", label: "Winter" },
-  { value: "ganzjährig", label: "Ganzjährig" },
-];
+// BLOG_CATEGORIES und SEASONS werden seit der Zentralisierung aus
+// src/config/blog.config.ts importiert, damit Frontend und Backend
+// immer die gleichen Werte verwenden.
 
 const AUDIENCE_OPTIONS = [
   "Anfänger", "Fortgeschrittene", "Familien", "Singles", "Kinder", "Senioren"

--- a/src/components/admin/ContentStrategyDashboard.tsx
+++ b/src/components/admin/ContentStrategyDashboard.tsx
@@ -30,13 +30,14 @@ interface CategoryContentGap {
 }
 
 const BLOG_CATEGORIES = [
-  { id: 'gaertnern', name: 'Gärtnern', icon: '🌱', keywords: ['garten', 'pflanzen', 'aussaat', 'ernte', 'pflege'] },
-  { id: 'gartenkueche', name: 'Gartenküche', icon: '👩‍🍳', keywords: ['kochen', 'rezept', 'ernte', 'kräuter', 'saisonal'] },
-  { id: 'diy-basteln', name: 'DIY & Basteln', icon: '🔨', keywords: ['diy', 'basteln', 'selbermachen', 'bauen', 'upcycling'] },
-  { id: 'nachhaltigkeit', name: 'Nachhaltigkeit', icon: '♻️', keywords: ['nachhaltig', 'umwelt', 'bio', 'plastikfrei', 'zero waste'] },
-  { id: 'indoor-gardening', name: 'Indoor Gardening', icon: '🏠', keywords: ['indoor', 'zimmerpflanzen', 'hydroponik', 'sprossen'] },
-  { id: 'saisonales', name: 'Saisonales', icon: '🍂', keywords: ['saison', 'frühling', 'sommer', 'herbst', 'winter'] },
-  { id: 'lifestyle', name: 'Lifestyle', icon: '✨', keywords: ['lifestyle', 'gesundheit', 'wellness', 'selbstversorgung'] }
+  { id: 'garten-planung', name: 'Garten & Planung', icon: '🌱', keywords: ['garten', 'planung', 'hochbeet', 'beet', 'aussaat', 'permakultur'] },
+  { id: 'pflanzenpflege', name: 'Pflanzenpflege', icon: '🌿', keywords: ['gießen', 'düngen', 'schneiden', 'schädlingsbekämpfung', 'bodenpflege'] },
+  { id: 'ernte-kueche', name: 'Ernte & Küche', icon: '🍅', keywords: ['rezepte', 'ernte', 'konservieren', 'küche', 'lagerung'] },
+  { id: 'nachhaltigkeit-umwelt', name: 'Nachhaltigkeit & Umwelt', icon: '♻️', keywords: ['nachhaltig', 'umwelt', 'bio', 'plastikfrei', 'permakultur'] },
+  { id: 'spezielle-gartenbereiche', name: 'Spezielle Gartenbereiche', icon: '🏡', keywords: ['urban', 'balkon', 'indoor', 'gewächshaus', 'hydroponik'] },
+  { id: 'selbermachen-ausruestung', name: 'Selbermachen & Ausrüstung', icon: '🔨', keywords: ['diy', 'basteln', 'werkzeug', 'upcycling', 'bauen'] },
+  { id: 'philosophie-lifestyle', name: 'Philosophie & Lifestyle', icon: '✨', keywords: ['selbstversorgung', 'achtsamkeit', 'lifestyle', 'wellness', 'inspiration'] },
+  { id: 'allgemein', name: 'Allgemein', icon: '📚', keywords: ['tipps', 'tricks', 'ratgeber', 'grundlagen'] }
 ];
 
 const ContentStrategyDashboard: React.FC = () => {
@@ -97,54 +98,61 @@ const ContentStrategyDashboard: React.FC = () => {
 
   const generateMissingTopicsForCategory = (category: any, currentCount: number): string[] => {
     const topicSuggestions: Record<string, string[]> = {
-      'gaertnern': [
+      'garten-planung': [
         'Hochbeet anlegen für Anfänger',
         'Kompost richtig anlegen',
         'Mischkultur Tipps',
         'Garten im Herbst vorbereiten',
         'Natürliche Schädlingsbekämpfung'
       ],
-      'gartenkueche': [
+      'pflanzenpflege': [
+        'Richtig gießen im Sommer',
+        'Natürliche Dünger selber machen',
+        'Pflanzen vor Schädlingen schützen',
+        'Überwinterung empfindlicher Arten',
+        'Schnitt-Tipps für Obstgehölze'
+      ],
+      'ernte-kueche': [
         'Kräuter konservieren',
         'Fermentieren für Anfänger',
         'Zero Waste in der Küche',
         'Saisonaler Ernährungsplan',
         'Essbare Blüten verwenden'
       ],
-      'diy-basteln': [
+      'selbermachen-ausruestung': [
         'Upcycling Gartenmöbel',
         'Pflanzgefäße selber machen',
         'Gewächshaus DIY',
         'Gartenwerkzeug reparieren',
         'Kompostbehälter bauen'
       ],
-      'nachhaltigkeit': [
+      'nachhaltigkeit-umwelt': [
         'Plastikfrei gärtnern',
         'Regenwasser sammeln',
         'Permakultur Grundlagen',
         'Naturdünger herstellen',
         'Klimafreundlich gärtnern'
       ],
-      'indoor-gardening': [
-        'Microgreens anbauen',
-        'Zimmerpflanzen für Anfänger',
+      'spezielle-gartenbereiche': [
+        'Urban Gardening auf dem Balkon',
         'Hydroponik Setup',
-        'Kräuter auf der Fensterbank',
-        'Indoor Kompostierung'
+        'Gewächshaus richtig nutzen',
+        'Balkongarten pflegen',
+        'Innenraumbegrünung leicht gemacht'
       ],
-      'saisonales': [
-        'Frühlingsarbeiten im Garten',
-        'Winterschutz für Pflanzen',
-        'Herbsternte einlagern',
-        'Sommergemüse anbauen',
-        'Ganzjähriger Anbauplan'
-      ],
-      'lifestyle': [
+      'philosophie-lifestyle': [
         'Selbstversorgung beginnen',
         'Garten als Therapie',
         'Achtsames Gärtnern',
         'Work-Life-Balance durch Garten',
         'Minimalismus im Garten'
+      ],
+      'allgemein': [
+        'Tipps für den Saisonstart',
+        'Bewährte Garten-Hacks',
+        'Werkzeugpflege leicht gemacht',
+        'So gelingt der Kompost',
+        'Fragen aus der Community beantwortet'
       ]
     };
 
@@ -158,11 +166,10 @@ const ContentStrategyDashboard: React.FC = () => {
     // Basis-Priorität basierend auf fehlenden Artikeln
     let priority = Math.max(0, 10 - articleCount);
     
-    // Saisonale Kategorien bekommen Boost
-    if (categoryId === 'saisonales') priority += 2;
-    
-    // Core-Kategorien bekommen Boost
-    if (['gaertnern', 'gartenkueche'].includes(categoryId)) priority += 1;
+    // Bestimmte Kategorien erhalten einen kleinen Prioritäts-Boost
+    if (categoryId === 'spezielle-gartenbereiche') priority += 2;
+
+    if (['garten-planung', 'pflanzenpflege', 'ernte-kueche'].includes(categoryId)) priority += 1;
     
     return priority * 10; // Skalierung für bessere Darstellung
   };

--- a/src/components/admin/PersonalizedContentGenerator.tsx
+++ b/src/components/admin/PersonalizedContentGenerator.tsx
@@ -24,8 +24,12 @@ const PersonalizedContentGenerator: React.FC = () => {
   const [loading, setLoading] = useState(false);
 
   const categories = [
-    "gartenplanung", "saisonale-kueche", "nachhaltigkeit", 
-    "diY-projekte", "ernte", "selbstversorgung"
+    "garten-planung",
+    "pflanzenpflege",
+    "ernte-kueche",
+    "selbermachen-ausruestung",
+    "nachhaltigkeit-umwelt",
+    "philosophie-lifestyle"
   ];
 
   const handleCategoryToggle = (category: string) => {

--- a/src/components/admin/views/BlogPodcastFilter.tsx
+++ b/src/components/admin/views/BlogPodcastFilter.tsx
@@ -58,11 +58,11 @@ const BlogPodcastFilter: React.FC<BlogPodcastFilterProps> = ({
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="all">Alle Kategorien</SelectItem>
-            <SelectItem value="kochen">Kochen</SelectItem>
-            <SelectItem value="gaertnern">Gärtnern</SelectItem>
-            <SelectItem value="nachhaltig-leben">Nachhaltig Leben</SelectItem>
-            <SelectItem value="diy-basteln">DIY & Basteln</SelectItem>
-            <SelectItem value="saisonales">Saisonales</SelectItem>
+            <SelectItem value="garten-planung">Garten & Planung</SelectItem>
+            <SelectItem value="pflanzenpflege">Pflanzenpflege</SelectItem>
+            <SelectItem value="ernte-kueche">Ernte & Küche</SelectItem>
+            <SelectItem value="selbermachen-ausruestung">Selbermachen & Ausrüstung</SelectItem>
+            <SelectItem value="nachhaltigkeit-umwelt">Nachhaltigkeit & Umwelt</SelectItem>
           </SelectContent>
         </Select>
 

--- a/src/components/blog/SimpleBlogFilter.tsx
+++ b/src/components/blog/SimpleBlogFilter.tsx
@@ -2,13 +2,14 @@ import React, { useState, useEffect, useMemo } from "react";
 import { Search, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { SEASONS } from "@/config/blog.config";
 
 // Vereinfachte Hauptkategorien (nur 4 statt 7)
 const MAIN_CATEGORIES = [
-  { id: 'gaertnern', name: 'Garten', icon: '🌱' },
-  { id: 'gartenküche', name: 'Küche', icon: '🍅' },
-  { id: 'diy-basteln', name: 'DIY', icon: '🔨' },
-  { id: 'nachhaltigkeit', name: 'Nachhaltig', icon: '♻️' }
+  { id: 'garten-planung', name: 'Garten', icon: '🌱' },
+  { id: 'ernte-kueche', name: 'Küche', icon: '🍅' },
+  { id: 'selbermachen-ausruestung', name: 'DIY', icon: '🔨' },
+  { id: 'nachhaltigkeit-umwelt', name: 'Nachhaltig', icon: '♻️' }
 ];
 
 interface SimpleBlogFilterProps {
@@ -155,17 +156,17 @@ const SimpleBlogFilter: React.FC<SimpleBlogFilterProps> = ({
             >
               Alle
             </button>
-            {['frühling', 'sommer', 'herbst', 'winter'].map((season) => (
+            {SEASONS.filter(s => s.value !== 'Ganzjährig').map(({ value, label }) => (
               <button
-                key={season}
-                onClick={() => setSelectedSeason(season)}
+                key={value.toLowerCase()}
+                onClick={() => setSelectedSeason(value.toLowerCase())}
                 className={`px-3 py-1 rounded-full text-xs transition-all ${
-                  selectedSeason === season
+                  selectedSeason === value.toLowerCase()
                     ? 'bg-sage-600 text-white'
                     : 'bg-sage-100 text-sage-700 hover:bg-sage-200'
                 }`}
               >
-                {season.charAt(0).toUpperCase() + season.slice(1)}
+                {label}
               </button>
             ))}
           </div>

--- a/src/pages/AussaatkalenderPage.tsx
+++ b/src/pages/AussaatkalenderPage.tsx
@@ -63,10 +63,10 @@ const AussaatkalenderPage: React.FC = () => {
           </p>
           <div className="flex flex-wrap justify-center gap-4">
             <Button asChild size="lg" className="bg-sage-600 hover:bg-sage-700">
-              <a href="/blog?category=aussaat-pflanzung">Aussaat & Pflanzung Tipps</a>
+              <a href="/blog?category=garten-planung">Aussaat & Pflanzung Tipps</a>
             </Button>
             <Button asChild variant="outline" size="lg">
-              <a href="/blog?category=saisonale-kueche">Saisonale Rezepte</a>
+              <a href="/blog?category=ernte-kueche">Saisonale Rezepte</a>
             </Button>
           </div>
         </div>

--- a/src/services/ContentStrategyService.ts
+++ b/src/services/ContentStrategyService.ts
@@ -31,13 +31,13 @@ interface PersonalizationProfile {
 
 class ContentStrategyService {
   private strategicKeywords = {
-    "gaertnern": ["Hochbeet", "Kompost", "Mischkultur", "Permakultur", "Aussaat", "Pflege"],
-    "gartenkueche": ["Fermentieren", "Einkochen", "Kräuter", "Saisonal", "Zero Waste", "Regional"],
-    "diy-basteln": ["Upcycling", "Selbermachen", "Bauen", "Reparieren", "Gartenmöbel", "Werkzeug"],
-    "nachhaltigkeit": ["Plastikfrei", "Klimafreundlich", "Regenerativ", "Naturgarten", "Kreislauf"],
-    "indoor-gardening": ["Zimmerpflanzen", "Hydroponik", "Microgreens", "Sprossen", "Keimlinge"],
-    "saisonales": ["Frühling", "Sommer", "Herbst", "Winter", "Erntezeit", "Aussaatzeit"],
-    "lifestyle": ["Selbstversorgung", "Achtsamkeit", "Work-Life-Balance", "Minimalismus", "Wellness"]
+    "garten-planung": ["Hochbeet", "Kompost", "Mischkultur", "Permakultur", "Aussaat", "Planung"],
+    "pflanzenpflege": ["Gießen", "Düngen", "Schnitt", "Schädlinge", "Bodenpflege", "Kompost"],
+    "ernte-kueche": ["Fermentieren", "Einkochen", "Kräuter", "Saisonal", "Zero Waste", "Lagerung"],
+    "selbermachen-ausruestung": ["Upcycling", "Selbermachen", "Bauen", "Reparieren", "Werkzeug"],
+    "nachhaltigkeit-umwelt": ["Plastikfrei", "Klimafreundlich", "Regenerativ", "Naturgarten", "Kreislauf"],
+    "spezielle-gartenbereiche": ["Urban", "Balkon", "Indoor", "Hydroponik", "Gewächshaus"],
+    "philosophie-lifestyle": ["Selbstversorgung", "Achtsamkeit", "Work-Life-Balance", "Minimalismus", "Wellness"]
   };
 
   async generateContentStrategy(context: {
@@ -105,13 +105,13 @@ class ContentStrategyService {
     
     // Prioritäten für verschiedene Kategorien
     const categoryPriorities = {
-      "gaertnern": 95,
-      "gartenkueche": 90,
-      "nachhaltigkeit": 85,
-      "saisonales": 80,
-      "diy-basteln": 75,
-      "indoor-gardening": 70,
-      "lifestyle": 65
+      "garten-planung": 95,
+      "pflanzenpflege": 90,
+      "ernte-kueche": 90,
+      "nachhaltigkeit-umwelt": 85,
+      "spezielle-gartenbereiche": 80,
+      "selbermachen-ausruestung": 75,
+      "philosophie-lifestyle": 65
     };
 
     Object.entries(this.strategicKeywords).forEach(([category, keywords]) => {
@@ -141,7 +141,7 @@ class ContentStrategyService {
     return [
       {
         priority: 90,
-        category: "gaertnern",
+        category: "garten-planung",
         season: currentSeason,
         suggestedTopics: [
           "Hochbeet optimal nutzen - Marianne's bewährte Methoden",
@@ -153,7 +153,7 @@ class ContentStrategyService {
       },
       {
         priority: 85,
-        category: "gartenkueche",
+        category: "ernte-kueche",
         season: currentSeason,
         suggestedTopics: [
           "Saisonale Rezepte direkt aus dem Garten",

--- a/src/utils/smartCategoryMapping.ts
+++ b/src/utils/smartCategoryMapping.ts
@@ -2,73 +2,74 @@
 // Smart Category Mapping basierend auf Tags
 export const SMART_CATEGORIES = [
   {
-    id: 'gaertnern',
-    name: 'Gärtnern',
+    id: 'garten-planung',
+    name: 'Garten & Planung',
     icon: '🌱',
     keywords: [
-      'garten', 'pflanzen', 'aussaat', 'ernte', 'pflege', 'beet', 'hochbeet',
-      'kompost', 'düngen', 'gießen', 'schneiden', 'schädlinge', 'bodenpflege',
-      'permakultur', 'mischkultur', 'mulchen', 'gewächshaus', 'balkon'
+      'garten', 'planung', 'aussaat', 'beet', 'hochbeet', 'permakultur',
+      'kompost', 'bodenpflege', 'mischkultur', 'gewächshaus', 'balkon'
     ]
   },
   {
-    id: 'gartenküche',
-    name: 'Gartenküche',
-    icon: '👩‍🍳',
+    id: 'pflanzenpflege',
+    name: 'Pflanzenpflege',
+    icon: '🌿',
     keywords: [
-      'kochen', 'rezept', 'küche', 'ernte', 'einkochen', 'konservieren',
-      'haltbarmachen', 'lagerung', 'kräuter', 'gewürze', 'saisonal',
-      'frisch', 'gesund', 'regional', 'bio'
+      'gießen', 'düngen', 'schneiden', 'schädlinge', 'krankheiten',
+      'pflegetipps', 'kompost', 'boden'
     ]
   },
   {
-    id: 'diy-basteln',
-    name: 'DIY & Basteln',
+    id: 'ernte-kueche',
+    name: 'Ernte & Küche',
+    icon: '🍅',
+    keywords: [
+      'kochen', 'rezept', 'ernte', 'einkochen', 'konservieren',
+      'haltbarmachen', 'lagerung', 'kräuter', 'saisonal', 'regional'
+    ]
+  },
+  {
+    id: 'selbermachen-ausruestung',
+    name: 'Selbermachen & Ausrüstung',
     icon: '🔨',
     keywords: [
-      'diy', 'basteln', 'selbermachen', 'bauen', 'werkzeug', 'upcycling',
-      'kreativ', 'handwerk', 'anleitung', 'projekt', 'reparieren',
-      'gartenmöbel', 'dekoration', 'holz', 'recycling'
+      'diy', 'basteln', 'selbermachen', 'bauen', 'werkzeug',
+      'upcycling', 'projekt', 'reparieren', 'gartenmöbel'
     ]
   },
   {
-    id: 'nachhaltigkeit',
-    name: 'Nachhaltigkeit',
+    id: 'nachhaltigkeit-umwelt',
+    name: 'Nachhaltigkeit & Umwelt',
     icon: '♻️',
     keywords: [
-      'nachhaltig', 'umwelt', 'öko', 'bio', 'plastikfrei', 'zero waste',
-      'klimaschutz', 'ressourcen', 'sparen', 'naturschutz', 'regenerativ',
-      'kreislauf', 'energy', 'wassersparen', 'kompost'
+      'nachhaltig', 'umwelt', 'bio', 'plastikfrei', 'zero waste',
+      'klimaschutz', 'ressourcen', 'regenerativ', 'kreislauf', 'wassersparen'
     ]
   },
   {
-    id: 'indoor-gardening',
-    name: 'Indoor Gardening',
-    icon: '🏠',
+    id: 'spezielle-gartenbereiche',
+    name: 'Spezielle Gartenbereiche',
+    icon: '🏡',
     keywords: [
-      'indoor', 'zimmerpflanzen', 'innen', 'hydroponik', 'keimlinge',
-      'sprossen', 'fensterbrett', 'grow light', 'topf', 'container',
-      'microgreens', 'kräuter innen', 'wohnung'
+      'urban', 'balkon', 'indoor', 'hydroponik', 'gewächshaus',
+      'container', 'microgreens'
     ]
   },
   {
-    id: 'saisonales',
-    name: 'Saisonales',
-    icon: '🍂',
-    keywords: [
-      'saison', 'saisonal', 'frühling', 'sommer', 'herbst', 'winter',
-      'jahreszeit', 'kalender', 'monat', 'zeit', 'wetter', 'klima',
-      'erntezeit', 'aussaatzeit', 'pflanzzeit'
-    ]
-  },
-  {
-    id: 'lifestyle',
-    name: 'Lifestyle',
+    id: 'philosophie-lifestyle',
+    name: 'Philosophie & Lifestyle',
     icon: '✨',
     keywords: [
-      'lifestyle', 'leben', 'gesundheit', 'wellness', 'entspannung',
-      'achtsamkeit', 'natur', 'philosophie', 'inspiration', 'tipps',
-      'routine', 'balance', 'selbstversorgung', 'minimalismus'
+      'lifestyle', 'gesundheit', 'wellness', 'entspannung', 'achtsamkeit',
+      'philosophie', 'inspiration', 'selbstversorgung', 'minimalismus'
+    ]
+  },
+  {
+    id: 'allgemein',
+    name: 'Allgemein',
+    icon: '📚',
+    keywords: [
+      'tipps', 'tricks', 'grundlagen', 'ratgeber', 'praxis'
     ]
   }
 ];
@@ -84,7 +85,7 @@ export const SEASONS = [
 export function assignSmartCategory(tags: string[], content: string = '', title: string = ''): string {
   const allText = `${title} ${content} ${tags.join(' ')}`.toLowerCase();
   
-  let bestMatch = { category: 'lifestyle', score: 0 };
+  let bestMatch = { category: 'philosophie-lifestyle', score: 0 };
   
   SMART_CATEGORIES.forEach(category => {
     let score = 0;


### PR DESCRIPTION
## Summary
- use centralized blog categories in BlogMetaSection
- update podcast filter dropdown
- sync simplified blog filter categories with core config
- modernize content strategy dashboard with new categories
- align personalized content generator defaults
- update page links for new categories
- refactor content strategy service mappings
- refresh smart category mapping

## Testing
- `npm run lint`
- `npx vitest run` *(failed: include/exclude output, likely due to env restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6887243839fc83208462abcac0d68928